### PR TITLE
[Taxa de não adesão] Adiciona destaque no Histórico temporal

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@emotion/styled": "^11.10.6",
-    "@impulsogov/design-system": "^1.0.27",
+    "@impulsogov/design-system": "^1.0.31",
     "@mui/material": "^5.12.0",
     "@mui/x-data-grid": "^6.1.0",
     "axios": "^1.3.4",

--- a/pages/caps/taxadeabandono/index.js
+++ b/pages/caps/taxadeabandono/index.js
@@ -150,10 +150,11 @@ const TaxaAbandono = () => {
       }
 
       <GraficoInfo
-        titulo="Histórico Temporal - Taxa de não adesão mensal"
+        titulo="Histórico Temporal"
         descricao="Dos usuários acolhidos há menos de 3 meses, quantos não aderiram ao serviço no mês"
         tooltip="Diferente do indicador de não adesão acumulado, que mostra o percentual de usuários que iniciaram o vínculo em um determinado mês e em até 3 meses deixaram de frequentar o CAPS, a taxa de não adesão mensal mostra o percentual de usuários recentes que deixaram de frequentar o serviço em um mês específico. Ou seja, o indicador mensal mostra qual foi o mês que o usuário iniciou o período de inatividade (que precisa ser igual ou superior a 3 meses)."
         fonte="Fonte: RAAS/SIASUS - Elaboração Impulso Gov"
+        destaque="Por que esses valores são diferentes?"
       />
 
       { abandonoMensal.length !== 0 &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,10 +1142,10 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@impulsogov/design-system@^1.0.27":
-  version "1.0.27"
-  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.27.tgz#afa225c5a70adf682d9cc74b25fc4df490fc6a59"
-  integrity sha512-wcZqR15kUQODT6kgD5EdLmPZTy/AMKaAccIdW7lfHxDId7iQ+y6JF9PWuZjLeA2KLuZiPHPJ/LpHpR3TTHoabw==
+"@impulsogov/design-system@^1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@impulsogov/design-system/-/design-system-1.0.31.tgz#2fe45f81c89ba0a1b792701383edae99f3ea7e5c"
+  integrity sha512-GKIwU0EXn6uPaYeFwvhPvyAPWzrb2inFFBFGTIUhT5GAk5Q9Kkzd3kYDOA6oqNa8WJwAA05MmiwlX08c+9SALQ==
   dependencies:
     "@babel/cli" "^7.18.9"
     "@babel/core" "^7.18.9"


### PR DESCRIPTION
## Contexto
O gráfico de Histórico temporal do painel de Taxa de não adesão estava sem a frase de destaque em azul:

![image](https://user-images.githubusercontent.com/45800622/235672970-3565a3ca-1186-4dc4-83b3-1f551f2b094a.png)

## Objetivo
Adicionar a frase de destaque `Por que esses valores são diferentes?` no gráfico de Histórico temporal
