### PR TITLE
Trata exceções nas páginas de ambulatório

### DIFF
--- a/helpers/mostrarDadosDeAmbulatorio.js
+++ b/helpers/mostrarDadosDeAmbulatorio.js
@@ -1,0 +1,32 @@
+const MUNICIPIOS_ID_SUS_SEM_AMBULATORIO = [
+  '230190',
+  '352590',
+  '320500'
+];
+
+const MUNICIPIOS_ID_SUS_SEM_DADOS_AMBULATORIO = [
+  '150140',
+  '351640',
+  '431440',
+  '292740',
+  '315780',
+  '320520',
+  '230440'
+];
+
+export const mostrarCardsDeResumoAmbulatorio = (municipioIdSus) => {
+  const MUNICIPIOS_ID_SUS_SEM_CARD_AMBULATORIO_RESUMO = [
+    ...MUNICIPIOS_ID_SUS_SEM_AMBULATORIO,
+    ...MUNICIPIOS_ID_SUS_SEM_DADOS_AMBULATORIO
+  ];
+
+  return !MUNICIPIOS_ID_SUS_SEM_CARD_AMBULATORIO_RESUMO.includes(municipioIdSus);
+};
+
+export const mostrarMensagemSemAmbulatorio = (municipioIdSus) => {
+  return MUNICIPIOS_ID_SUS_SEM_AMBULATORIO.includes(municipioIdSus);
+};
+
+export const mostrarMensagemSemDadosAmbulatorio = (municipioIdSus) => {
+  return MUNICIPIOS_ID_SUS_SEM_DADOS_AMBULATORIO.includes(municipioIdSus);
+};

--- a/pages/outros-raps/ambulatorio/index.js
+++ b/pages/outros-raps/ambulatorio/index.js
@@ -67,12 +67,11 @@ const Ambulatorio = () => {
           posicao: null,
           url: ''
         } }
-        texto=''
+        texto='Essa página não está exibindo dados porque a coordenação da RAPS informou que não há ambulatórios da rede especializada que realizam atendimentos de Saúde Mental com psicólogos e psiquiatras em seu município. Caso queira solicitar a inclusão de um novo estabelecimento ambulatorial, entre em contato via nosso <u><a style="color:inherit" href="/duvidas" target="_blank">formulário de solicitação de suporte</a></u>, <u><a style="color:inherit" href="https://wa.me/5511941350260" target="_blank">whatsapp</a></u> ou e-mail (saudemental@impulsogov.org).'
         botao={{
           label: '',
           url: ''
         }}
-        titulo='<strong>Município sem ambulatório</strong>'
       />
     );
   }
@@ -84,12 +83,13 @@ const Ambulatorio = () => {
           posicao: null,
           url: ''
         } }
-        texto=''
+        texto='O indicador de ambulatório utiliza dados da atenção especializada que são coletados através dos registros de psicólogos e psiquiatras em fichas de BPA-i. São considerados os estabelecimentos indicados no momento do preenchimento do Formulário de Personalização do Painel, feito pela coordenação da RAPS no município.
+        <br/>
+        Se essa página não está exibindo nenhum dado da sua rede, verifique se o estabelecimento está habilitado a registrar em BPA-i (como no caso de ambulatórios vinculados a Atenção Básica que registram via SISAB), ou se existem problemas de registro.'
         botao={{
           label: '',
           url: ''
         }}
-        titulo='<strong>Município sem dados de ambulatório</strong>'
       />
     );
   }

--- a/pages/outros-raps/resumo/index.js
+++ b/pages/outros-raps/resumo/index.js
@@ -3,6 +3,7 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 import { v1 as uuidv1 } from 'uuid';
 import { redirectHomeNotLooged } from '../../../helpers/RedirectHome';
+import { mostrarCardsDeResumoAmbulatorio } from '../../../helpers/mostrarDadosDeAmbulatorio';
 import { getAcoesReducaoDeDanos, getAcoesReducaoDeDanos12meses, getAtendimentosAmbulatorioResumoUltimoMes, getAtendimentosConsultorioNaRua, getAtendimentosConsultorioNaRua12meses } from '../../../requests/outros-raps';
 
 export function getServerSideProps(ctx) {
@@ -29,9 +30,12 @@ const Resumo = () => {
       );
       setReducaoDanos(await getAcoesReducaoDeDanos(municipioIdSus));
       setReducaoDanos12Meses(await getAcoesReducaoDeDanos12meses(municipioIdSus));
-      setAmbulatorioUltMes(
-        await getAtendimentosAmbulatorioResumoUltimoMes(municipioIdSus)
-      );
+
+      if (mostrarCardsDeResumoAmbulatorio(municipioIdSus)) {
+        setAmbulatorioUltMes(
+          await getAtendimentosAmbulatorioResumoUltimoMes(municipioIdSus)
+        );
+      }
     };
 
     if (session?.user.municipio_id_ibge) {
@@ -80,47 +84,51 @@ const Resumo = () => {
           url: ''
         } }
         texto=''
-        botao={{
+        botao={ {
           label: '',
           url: ''
-        }}
+        } }
         titulo='<strong>Resumo</strong>'
       />
 
-      <GraficoInfo
-        titulo='Ambulatório de Saúde Mental'
-        fonte='Fonte: BPA/SIASUS - Elaboração Impulso Gov'
-        link={ { label: 'Mais informações', url: '/outros-raps?painel=1' } }
-      />
+      { mostrarCardsDeResumoAmbulatorio(session?.user.municipio_id_ibge) &&
+        <>
+          <GraficoInfo
+            titulo='Ambulatório de Saúde Mental'
+            fonte='Fonte: BPA/SIASUS - Elaboração Impulso Gov'
+            link={ { label: 'Mais informações', url: '/outros-raps?painel=1' } }
+          />
 
-      <Grid12Col
-        items={ [
-          <>
-            { ambulatorioUltMes.length !== 0
-              ? <CardInfoTipoA
-                key={ uuidv1() }
-                indicador={ getDadosAmbulatorioUltimoMes().procedimentos_realizados }
-                titulo={ `Total de atendimentos em ${getDadosAmbulatorioUltimoMes().nome_mes}` }
-                indice={ getDadosAmbulatorioUltimoMes().dif_procedimentos_realizados_anterior }
-                indiceDescricao='últ. mês'
-              />
-              : <Spinner theme='ColorSM' />
-            }
-          </>,
-          <>
-            { ambulatorioUltMes.length !== 0
-              ? <CardInfoTipoA
-                key={ uuidv1() }
-                indicador={ getDadosAmbulatorioUltimoMes().procedimentos_por_hora }
-                titulo={ `Total de atendimentos por hora trabalhada em ${getDadosAmbulatorioUltimoMes().nome_mes}` }
-                indice={ getDadosAmbulatorioUltimoMes().dif_procedimentos_por_hora_anterior }
-                indiceDescricao='últ. mês'
-              />
-              : <Spinner theme='ColorSM' />
-            }
-          </>,
-        ] }
-      />
+          <Grid12Col
+            items={ [
+              <>
+                { ambulatorioUltMes.length !== 0
+                  ? <CardInfoTipoA
+                    key={ uuidv1() }
+                    indicador={ getDadosAmbulatorioUltimoMes().procedimentos_realizados }
+                    titulo={ `Total de atendimentos em ${getDadosAmbulatorioUltimoMes().nome_mes}` }
+                    indice={ getDadosAmbulatorioUltimoMes().dif_procedimentos_realizados_anterior }
+                    indiceDescricao='últ. mês'
+                  />
+                  : <Spinner theme='ColorSM' />
+                }
+              </>,
+              <>
+                { ambulatorioUltMes.length !== 0
+                  ? <CardInfoTipoA
+                    key={ uuidv1() }
+                    indicador={ getDadosAmbulatorioUltimoMes().procedimentos_por_hora }
+                    titulo={ `Total de atendimentos por hora trabalhada em ${getDadosAmbulatorioUltimoMes().nome_mes}` }
+                    indice={ getDadosAmbulatorioUltimoMes().dif_procedimentos_por_hora_anterior }
+                    indiceDescricao='últ. mês'
+                  />
+                  : <Spinner theme='ColorSM' />
+                }
+              </>,
+            ] }
+          />
+        </>
+      }
 
       <GraficoInfo
         titulo='Consultório na Rua'


### PR DESCRIPTION
### Objetivo
- Evitar que as páginas de **Resumo** e **Ambulatório** do painel de **Outros serviços RAPS** quebrem para municípios que não possuem ambulatório ou que não terão dados de ambulatório exibidos por questões de registro.

### Alterações feitas
- Adiciona _helpers_ para controlar exibição dos dados de ambulatório
- Remove renderização dos cards de ambulatório na página de **Resumo** para municípios sem ambulatório ou sem dados de ambulatório
- Exibe mensagem explicativa na página de **Ambulatório** para municípios sem ambulatório ou sem dados de ambulatório