### PR TITLE
[Refatoração] Cria componente GraficoDonut

### DIFF
--- a/components/Graficos/Donut.jsx
+++ b/components/Graficos/Donut.jsx
@@ -1,0 +1,92 @@
+import { Spinner } from '@impulsogov/design-system';
+import ReactEcharts from 'echarts-for-react';
+import PropTypes from 'prop-types';
+import { useCallback, useMemo } from 'react';
+import { CORES_GRAFICO_DONUT, QUANTIDADE_CORES_GRAFICO_DONUT } from '../../constants/GRAFICO_DONUT';
+import { agregarQuantidadePorPropriedadeNome, agruparItensQueUltrapassamPaleta } from '../../helpers/graficoDonut';
+import { ordenarDecrescentePorPropriedadeNumerica } from '../../utils/ordenacao';
+
+const GraficoDonut = ({ dados, propriedades, loading }) => {
+  const dadosAgregadosEOrdenados = useMemo(() => {
+    const agregados = agregarQuantidadePorPropriedadeNome(
+      dados,
+      propriedades.nome,
+      propriedades.quantidade
+    );
+
+    return ordenarDecrescentePorPropriedadeNumerica(
+      agregados,
+      'quantidade'
+    );
+  }, [dados, propriedades]);
+
+  const gerarOptions = useCallback(() => {
+    let dadosGraficoDonut = dadosAgregadosEOrdenados;
+
+    if (dadosAgregadosEOrdenados.length > QUANTIDADE_CORES_GRAFICO_DONUT) {
+      dadosGraficoDonut = agruparItensQueUltrapassamPaleta(dadosAgregadosEOrdenados);
+    }
+
+    return {
+      tooltip: {
+        trigger: 'item',
+        valueFormatter: (value) => value,
+      },
+      series: [
+        {
+          type: 'pie',
+          radius: ['40%', '80%'],
+          avoidLabelOverlap: false,
+          label: {
+            show: true,
+            position: 'inside',
+            formatter: '{d}%',
+            color: '#000000'
+          },
+          emphasis: {
+            label: {
+              show: true,
+            }
+          },
+          labelLine: {
+            show: false
+          },
+          data: dadosGraficoDonut.map(({ nome, quantidade }, index) => ({
+            value: quantidade,
+            name: !nome ? 'Sem informação' : nome,
+            itemStyle: {
+              color: CORES_GRAFICO_DONUT[index]
+            },
+          }))
+        }
+      ]
+    };
+  }, [dadosAgregadosEOrdenados]);
+
+  return (
+    <>
+      { loading
+        ? <Spinner theme='ColorSM' height='70vh' />
+        : <ReactEcharts
+          option={ gerarOptions() }
+          style={ { width: '50%', height: '70vh' } }
+        />
+      }
+    </>
+  );
+};
+
+export default GraficoDonut;
+
+GraficoDonut.defaultProps = {
+  loading: false
+};
+
+GraficoDonut.propTypes = {
+  dados: PropTypes.array.isRequired,
+  propriedades: PropTypes.shape({
+    nome: PropTypes.string,
+    quantidade: PropTypes.string,
+  }).isRequired,
+  loading: PropTypes.bool
+};

--- a/components/Graficos/index.js
+++ b/components/Graficos/index.js
@@ -1,5 +1,7 @@
 import GraficoGeneroPorFaixaEtaria from './GeneroPorFaixaEtaria';
+import GraficoDonut from './Donut';
 
 export {
-  GraficoGeneroPorFaixaEtaria
+  GraficoGeneroPorFaixaEtaria,
+  GraficoDonut
 };

--- a/pages/caps/producao/index.js
+++ b/pages/caps/producao/index.js
@@ -6,13 +6,13 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { v1 as uuidv1 } from 'uuid';
 import { redirectHomeNotLooged } from '../../../helpers/RedirectHome';
 import { agregarPorPropriedadeESomarQuantidade, getOpcoesGraficoBarrasProducao } from '../../../helpers/graficoBarrasProducao';
-import { agregarQuantidadePorPropriedadeNome, getOpcoesGraficoDonut } from '../../../helpers/graficoDonut';
 import { getProcedimentosPorHora, getProcedimentosPorTipo } from '../../../requests/caps';
-import { ordenarCrescentePorPropriedadeDeTexto, ordenarDecrescentePorPropriedadeNumerica } from '../../../utils/ordenacao';
+import { ordenarCrescentePorPropriedadeDeTexto } from '../../../utils/ordenacao';
 import styles from '../Caps.module.css';
 import { ProcedimentosPorCaps } from '../../../components/ProcedimentosPorCaps';
 import { FiltroCompetencia, FiltroTexto } from '../../../components/Filtros';
 import {FILTRO_PERIODO_MULTI_DEFAULT, FILTRO_PERIODO_DEFAULT, FILTRO_ESTABELECIMENTO_DEFAULT} from '../../../constants/FILTROS';
+import { GraficoDonut } from '../../../components/Graficos';
 
 const OCUPACOES_NAO_ACEITAS = ['Todas', null];
 
@@ -185,30 +185,30 @@ const Producao = () => {
     'procedimentos_registrados_total'
   );
 
-  const agrupadosPorTipoBPA = useMemo(() => {
+  const procedimentosBPAFiltrados = useMemo(() => {
+    const dadosNaoZerados = procedimentosPorTipo
+      .filter(({ procedimentos_registrados_bpa: procedimentos }) => procedimentos !== 0);
+
     const dadosFiltrados = filtrarPorTipoEstabelecimentoEPeriodo(
-      procedimentosPorTipo,
+      dadosNaoZerados,
       filtroEstabelecimentoBPA,
       filtroPeriodoBPA
     );
-    const dadosAgregados = agregarQuantidadePorPropriedadeNome(dadosFiltrados, 'procedimento', 'procedimentos_registrados_bpa');
-    const dadosNaoZerados = dadosAgregados.filter(({ quantidade }) => quantidade !== 0);
-    const dadosOrdenados = ordenarDecrescentePorPropriedadeNumerica(dadosNaoZerados, 'quantidade');
 
-    return dadosOrdenados;
+    return dadosFiltrados;
   }, [filtrarPorTipoEstabelecimentoEPeriodo, filtroEstabelecimentoBPA, filtroPeriodoBPA, procedimentosPorTipo]);
 
-  const agrupadosPorTipoRAAS = useMemo(() => {
+  const procedimentosRAASFiltrados = useMemo(() => {
+    const dadosNaoZerados = procedimentosPorTipo
+      .filter(({ procedimentos_registrados_raas: procedimentos }) => procedimentos !== 0);
+
     const dadosFiltrados = filtrarPorTipoEstabelecimentoEPeriodo(
-      procedimentosPorTipo,
+      dadosNaoZerados,
       filtroEstabelecimentoRAAS,
       filtroPeriodoRAAS
     );
-    const dadosAgregados = agregarQuantidadePorPropriedadeNome(dadosFiltrados, 'procedimento', 'procedimentos_registrados_raas');
-    const dadosNaoZerados = dadosAgregados.filter(({ quantidade }) => quantidade !== 0);
-    const dadosOrdenados = ordenarDecrescentePorPropriedadeNumerica(dadosNaoZerados, 'quantidade');
 
-    return dadosOrdenados;
+    return dadosFiltrados;
   }, [filtrarPorTipoEstabelecimentoEPeriodo, filtroEstabelecimentoRAAS, filtroPeriodoRAAS, procedimentosPorTipo]);
 
   return (
@@ -319,9 +319,12 @@ const Producao = () => {
             </div>
 
             <div className={ styles.GraficoCIDContainer }>
-              <ReactEcharts
-                option={ getOpcoesGraficoDonut(agrupadosPorTipoBPA) }
-                style={ { width: '50%', height: '70vh' } }
+              <GraficoDonut
+                dados={ procedimentosBPAFiltrados }
+                propriedades={ {
+                  nome: 'procedimento',
+                  quantidade: 'procedimentos_registrados_bpa'
+                } }
               />
 
               <TabelaGraficoDonut
@@ -329,7 +332,11 @@ const Producao = () => {
                   colunaHeader: 'Nome do procedimento',
                   colunaQuantidade: 'Quantidade registrada',
                 } }
-                data={ agrupadosPorTipoBPA }
+                propriedades={ {
+                  nome: 'procedimento',
+                  quantidade: 'procedimentos_registrados_bpa'
+                } }
+                data={ procedimentosBPAFiltrados }
                 mensagemDadosZerados='Sem procedimentos registrados nessa competência'
               />
             </div>
@@ -366,9 +373,12 @@ const Producao = () => {
             </div>
 
             <div className={ styles.GraficoCIDContainer }>
-              <ReactEcharts
-                option={ getOpcoesGraficoDonut(agrupadosPorTipoRAAS) }
-                style={ { width: '50%', height: '70vh' } }
+              <GraficoDonut
+                dados={ procedimentosRAASFiltrados }
+                propriedades={ {
+                  nome: 'procedimento',
+                  quantidade: 'procedimentos_registrados_raas'
+                } }
               />
 
               <TabelaGraficoDonut
@@ -376,7 +386,11 @@ const Producao = () => {
                   colunaHeader: 'Nome do procedimento',
                   colunaQuantidade: 'Quantidade registrada',
                 } }
-                data={ agrupadosPorTipoRAAS }
+                propriedades={ {
+                  nome: 'procedimento',
+                  quantidade: 'procedimentos_registrados_raas'
+                } }
+                data={ procedimentosRAASFiltrados }
                 mensagemDadosZerados='Sem procedimentos registrados nessa competência'
               />
             </div>

--- a/pages/caps/taxadeabandono/index.js
+++ b/pages/caps/taxadeabandono/index.js
@@ -6,8 +6,7 @@ import { redirectHomeNotLooged } from '../../../helpers/RedirectHome';
 import { getAbandonoCoortes, getAbandonoMensal, getEstabelecimentos, getEvasoesNoMesPorCID, getEvasoesNoMesPorGeneroEIdade, getPeriodos } from '../../../requests/caps';
 import ReactEcharts from 'echarts-for-react';
 import { TabelaGraficoDonut } from '../../../components/Tabelas';
-import { agregarQuantidadePorPropriedadeNome, getOpcoesGraficoDonut } from '../../../helpers/graficoDonut';
-import { GraficoGeneroPorFaixaEtaria } from '../../../components/Graficos';
+import { GraficoDonut, GraficoGeneroPorFaixaEtaria } from '../../../components/Graficos';
 import { getOpcoesGraficoHistoricoTemporal } from '../../../helpers/graficoHistoricoTemporal';
 import { concatenarPeriodos } from '../../../utils/concatenarPeriodos';
 import { ordenarDecrescentePorPropriedadeNumerica } from '../../../utils/ordenacao';
@@ -135,16 +134,11 @@ const TaxaAbandono = () => {
       );
   };
 
-  const agregadosPorCID = useMemo(() => {
-    const dadosAgregados = agregarQuantidadePorPropriedadeNome(
-      evasoesNoMesPorCID,
-      'usuario_condicao_saude',
-      'quantidade_registrada'
-    );
-    const dadosNaoZerados = dadosAgregados.filter(({ quantidade }) => quantidade !== 0);
-    const dadosOrdenados = ordenarDecrescentePorPropriedadeNumerica(dadosNaoZerados, 'quantidade');
+  const evasoesNoMesPorCIDNaoZeradas = useMemo(() => {
+    const dadosNaoZerados = evasoesNoMesPorCID
+      .filter(({ quantidade_registrada: quantidade }) => quantidade !== 0);
 
-    return dadosOrdenados;
+    return dadosNaoZerados;
   }, [evasoesNoMesPorCID]);
 
   const getDadosFiltradosGeneroEFaixaEtaria = useMemo(() => {
@@ -252,24 +246,29 @@ const TaxaAbandono = () => {
               />
             </div>
 
-            { loadingCID
-              ? <Spinner theme='ColorSM' height='70vh' />
-              : <div className={ styles.GraficoCIDContainer }>
-                <ReactEcharts
-                  option={ getOpcoesGraficoDonut(agregadosPorCID) }
-                  style={ { width: '50%', height: '70vh' } }
-                />
+            <div className={ styles.GraficoCIDContainer }>
+              <GraficoDonut
+                dados={ evasoesNoMesPorCIDNaoZeradas }
+                propriedades={ {
+                  nome: 'usuario_condicao_saude',
+                  quantidade: 'quantidade_registrada'
+                } }
+                loading={ loadingCID }
+              />
 
-                <TabelaGraficoDonut
-                  labels={ {
-                    colunaHeader: 'Grupo de diagnósticos',
-                    colunaQuantidade: 'Evadiram no mês',
-                  } }
-                  data={ agregadosPorCID }
-                  mensagemDadosZerados='Sem usuários nessa competência'
-                />
-              </div>
-            }
+              <TabelaGraficoDonut
+                labels={ {
+                  colunaHeader: 'Grupo de diagnósticos',
+                  colunaQuantidade: 'Evadiram no mês',
+                } }
+                propriedades={ {
+                  nome: 'usuario_condicao_saude',
+                  quantidade: 'quantidade_registrada'
+                } }
+                data={ evasoesNoMesPorCIDNaoZeradas }
+                mensagemDadosZerados='Sem usuários nessa competência'
+              />
+            </div>
           </>
         )
         : <Spinner theme='ColorSM' />


### PR DESCRIPTION
### Objetivo
- Englobar a lógica do gráfico donut dentro de um componente reutilizável

### Mudanças feitas
- Criação do componente `GraficoDonut`
- Adição de nova prop na `TabelaGraficoDonut` e agregação dos dados feita dentro dela mesma a partir das mudanças feitas com a criação do `GraficoDonut`
- Utilização do `GraficoDonut` nas páginas:
  - Perfil de usuário
  - Novos usuários
  - Taxa de não adesão
  - Atendimentos Individuais
  - Produção
- Adição de nova prop da `TabelaGraficoDonut` nas páginas onde ela é usada

### Questionamentos para levar em consideração durante revisão
- Faria sentido criar um componente englobando o gráfico e a tabela já que eles são utilizados em conjunto e por isso têm lógica muito similar?
- Os nomes da pros desses componentes estão descritivos o suficiente para facilitar o entendimento?