### PR TITLE
[Correção] Remove dados zerados dos gráficos de condição de usuários

### DIFF
--- a/pages/caps/novosusuarios/index.js
+++ b/pages/caps/novosusuarios/index.js
@@ -251,19 +251,25 @@ const NovoUsuario = () => {
   }, [usuariosNovosPorGeneroEIdade]);
 
   const agregadosPorAbusoSubstancias = useMemo(() => {
-    return agregarPorAbusoSubstancias(
+    const dadosAgregados = agregarPorAbusoSubstancias(
       usuariosNovosPorCondicao,
       'usuario_abuso_substancias',
       'usuarios_novos'
     );
+    const dadosNaoZerados = dadosAgregados.filter(({ quantidade }) => quantidade !== 0);
+
+    return dadosNaoZerados;
   }, [usuariosNovosPorCondicao]);
 
   const agregadosPorSituacaoRua = useMemo(() => {
-    return agregarPorSituacaoRua(
+    const dadosAgregados = agregarPorSituacaoRua(
       usuariosNovosPorCondicao,
       'usuario_situacao_rua',
       'usuarios_novos'
     );
+    const dadosNaoZerados = dadosAgregados.filter(({ quantidade }) => quantidade !== 0);
+
+    return dadosNaoZerados;
   }, [usuariosNovosPorCondicao]);
 
   const agregadosPorRacaCor = useMemo(() => {

--- a/pages/caps/perfildousuario/index.js
+++ b/pages/caps/perfildousuario/index.js
@@ -197,19 +197,25 @@ const PerfilUsuario = () => {
   };
 
   const agregadosPorAbusoSubstancias = useMemo(() => {
-    return agregarPorAbusoSubstancias(
+    const dadosAgregados = agregarPorAbusoSubstancias(
       usuariosPorCondicao,
       'usuario_abuso_substancias',
       'ativos_3meses'
     );
+    const dadosNaoZerados = dadosAgregados.filter(({ quantidade }) => quantidade !== 0);
+
+    return dadosNaoZerados;
   }, [usuariosPorCondicao]);
 
   const agregadosPorSituacaoRua = useMemo(() => {
-    return agregarPorSituacaoRua(
+    const dadosAgregados = agregarPorSituacaoRua(
       usuariosPorCondicao,
       'usuario_situacao_rua',
       'ativos_3meses'
     );
+    const dadosNaoZerados = dadosAgregados.filter(({ quantidade }) => quantidade !== 0);
+
+    return dadosNaoZerados;
   }, [usuariosPorCondicao]);
 
   const agregadosPorGeneroEFaixaEtaria = useMemo(() => {


### PR DESCRIPTION
### Contexto
Os gráficos de Condição de usuários estavam exibindo dados zerados e esse não é o comportamento esperado. O ideal é que dados zerados não sejam exibidos como uma fatia do gráfico.

### Mudanças feitas
- Remoção de dados zerados para exibição nos gráficos