### PR TITLE
Remove estabelecimentos nulos dos filtros

### DIFF
--- a/components/Filtros/FiltroTexto.jsx
+++ b/components/Filtros/FiltroTexto.jsx
@@ -10,7 +10,9 @@ const FiltroTexto = ({ dados, label, propriedade, valor, setValor, isMulti, isSe
     const valoresUnicos = new Set();
 
     dados.forEach((dado) => {
-      valoresUnicos.add(dado[propriedade]);
+      if (dado[propriedade] !== null) {
+        valoresUnicos.add(dado[propriedade]);
+      }
     });
 
     return [...valoresUnicos]

--- a/components/Filtros/FiltroTexto.jsx
+++ b/components/Filtros/FiltroTexto.jsx
@@ -10,7 +10,7 @@ const FiltroTexto = ({ dados, label, propriedade, valor, setValor, isMulti, isSe
     const valoresUnicos = new Set();
 
     dados.forEach((dado) => {
-      if (dado[propriedade] !== null) {
+      if (dado[propriedade]) {
         valoresUnicos.add(dado[propriedade]);
       }
     });


### PR DESCRIPTION
### Contexto
Alguns estabelecimentos vinham nulos do banco e isso causava erro em algumas páginas

### Alterações feitas
- Remoção das opções nulas do componente de filtro