### PR TITLE
Remove requisições inutilizadas

### DIFF
--- a/requests/caps.js
+++ b/requests/caps.js
@@ -65,18 +65,6 @@ export const getResumoPerfilDeAtendimentos = async (municipioIdSus) => {
   }
 };
 
-export const getPerfilDeAtendimentos = async (municipioIdSus) => {
-  try {
-    const endpoint = "/atendimentosindividuais/caps/perfil?municipio_id_sus=" + municipioIdSus;
-
-    const { data } = await axiosInstance.get(endpoint);
-
-    return data;
-  } catch (error) {
-    console.log('error', error.response.data);
-  }
-};
-
 export const getAtendimentosPorCaps = async (municipioIdSus) => {
   try {
     const endpoint = "/atendimentosindividuais/porcaps?municipio_id_sus=" + municipioIdSus;

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -89,18 +89,6 @@ export const getAtendimentosPorCaps = async (municipioIdSus) => {
   }
 };
 
-// export const getProcedimentosPorTempoServico = async (municipioIdSus) => {
-//   try {
-//     const endpoint = "/procedimentos_por_usuario_tempo?municipio_id_sus=" + municipioIdSus;
-
-//     const { data } = await axiosInstance.get(endpoint);
-
-//     return data;
-//   } catch (error) {
-//     console.log('error', error.response.data);
-//   }
-// };
-
 export const getProcedimentosPorEstabelecimento = async (municipioIdSus) => {
   try {
     const endpoint = "/procedimentos_por_usuario_estabelecimentos?municipio_id_sus=" + municipioIdSus;
@@ -160,30 +148,6 @@ export const getAbandonoCoortes = async (municipioIdSus) => {
     console.log('error', error.response.data);
   }
 };
-
-// export const getProcedimentosPorTipo = async (municipioIdSus) => {
-//   try {
-//     const endpoint = "/procedimentos_por_tipo?municipio_id_sus=" + municipioIdSus;
-
-//     const { data } = await axiosInstance.get(endpoint);
-
-//     return data;
-//   } catch (error) {
-//     console.log('error', error.response.data);
-//   }
-// };
-
-// export const getProcedimentosPorHora = async (municipioIdSus) => {
-//   try {
-//     const endpoint = "/procedimentos_por_hora?municipio_id_sus=" + municipioIdSus;
-
-//     const { data } = await axiosInstance.get(endpoint);
-
-//     return data;
-//   } catch (error) {
-//     console.log('error', error.response.data);
-//   }
-// };
 
 export const getUsuariosAtivosPorCondicao = async (
   municipioIdSus,

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -29,18 +29,6 @@ export const getPerfilUsuariosPorEstabelecimento = async (municipioIdSus) => {
   }
 };
 
-export const getNovosUsuarios = async (municipioIdSus) => {
-  try {
-    const endpoint = "/usuarios/novos?municipio_id_sus=" + municipioIdSus;
-
-    const { data } = await axiosInstance.get(endpoint);
-
-    return data;
-  } catch (error) {
-    console.log('error', error.response.data);
-  }
-};
-
 export const getResumoNovosUsuarios = async (municipioIdSus) => {
   try {
     const endpoint = "/usuarios/novosresumo?municipio_id_sus=" + municipioIdSus;

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -125,18 +125,6 @@ export const getAbandonoMensal = async (municipioIdSus) => {
   }
 };
 
-export const getPerfilAbandono = async (municipioIdSus) => {
-  try {
-    const endpoint = "/abandono/resumo?municipio_id_sus=" + municipioIdSus;
-
-    const { data } = await axiosInstance.get(endpoint);
-
-    return data;
-  } catch (error) {
-    console.log('error', error.response.data);
-  }
-};
-
 export const getAbandonoCoortes = async (municipioIdSus) => {
   try {
     const endpoint = "/abandono/coortes?municipio_id_sus=" + municipioIdSus;


### PR DESCRIPTION
### Contexto
Com as refatorações na API de saúde mental para criar novos endpoints que não usassem parquets, alguns endpoints deixaram de ser utilizados, mas continuaram na base de código.

### Objetivo
Remover as requisições dos endpoints inutilizados para facilitar leitura, entendimento e uso da aplicação.