### PR TITLE
[Internações] Trata erro 404

### DIFF
--- a/requests/cuidado-compartilhado.js
+++ b/requests/cuidado-compartilhado.js
@@ -11,9 +11,16 @@ export const getCAPSAcolhimentoNoturno = async (municipioIdSus) => {
     const { data } = await axiosInstance.get(endpoint);
     return data;
   }  catch (error) {
+    if (error.response.status === 404) {
+      return [{
+        'acolhimentos_noturnos': 0,
+      }];
+    }
+
     console.log('error', error.response.data);
   }
 };
+
 export const getInternacoesRapsAltas = async (municipioIdSus) => {
   try {
     const endpoint = "/atencao_hospitalar/altas?municipio_id_sus=" + municipioIdSus;


### PR DESCRIPTION
### Objetivo
- Tratar erro 404 (quando dados do município não existem no banco) para que o card mostre o número de internações igual a 0 ao invés de carregar infinitamente