### PR TITLE
[Usuários e Procedimentos] Adição de novos endpoints com filtros e cache

### DIFF
--- a/components/CardsResumoEstabelecimentos/CardsResumoEstabelecimentos.jsx
+++ b/components/CardsResumoEstabelecimentos/CardsResumoEstabelecimentos.jsx
@@ -1,0 +1,79 @@
+import { CardInfoTipoA, GraficoInfo, Grid12Col, Spinner } from '@impulsogov/design-system';
+import React, { useMemo } from 'react';
+import { ordenarCrescentePorPropriedadeDeTexto } from '../../utils/ordenacao';
+
+const CardsResumoEstabelecimentos = ({
+  resumo,
+  propriedadesCard
+}) => {
+  const estabelecimentosLinhaDePerfilGeral = useMemo(() => {
+    const dadosFiltrados = resumo.filter((item) => item.estabelecimento_linha_perfil === 'Geral');
+
+    return ordenarCrescentePorPropriedadeDeTexto(
+      dadosFiltrados,
+      'estabelecimento'
+    );
+  }, [resumo]);
+
+  const estabelecimentosLinhaDePerfilAD = useMemo(() => {
+    const dadosFiltrados = resumo.filter((item) => item.estabelecimento_linha_perfil === 'Álcool e outras drogas');
+
+    return ordenarCrescentePorPropriedadeDeTexto(
+      dadosFiltrados,
+      'estabelecimento'
+    );
+  }, [resumo]);
+
+  return (
+    <>
+      { resumo.length !== 0
+        ? <>
+          <GraficoInfo
+            titulo={ `CAPS ${estabelecimentosLinhaDePerfilGeral[0].estabelecimento_linha_perfil}` }
+            descricao={ `Dados de ${estabelecimentosLinhaDePerfilGeral[0].nome_mes}` }
+          />
+
+          <Grid12Col
+            items={
+              estabelecimentosLinhaDePerfilGeral.map((item) => (
+                <CardInfoTipoA
+                  titulo={ item[propriedadesCard.estabelecimento] }
+                  indicador={ item[propriedadesCard.quantidade] }
+                  indice={ item[propriedadesCard.difAnterior] }
+                  indiceSimbolo={ item[propriedadesCard.simbolo] }
+                  indiceDescricao={ item[propriedadesCard.descricao] }
+                  key={ `${item.id}-${item[propriedadesCard.difAnterior]}` }
+                />
+              ))
+            }
+            proporcao='3-3-3-3'
+          />
+
+          <GraficoInfo
+            titulo={ `CAPS ${estabelecimentosLinhaDePerfilAD[0].estabelecimento_linha_perfil}` }
+            descricao={ `Dados de ${estabelecimentosLinhaDePerfilAD[0].nome_mes}` }
+          />
+
+          <Grid12Col
+            items={
+              estabelecimentosLinhaDePerfilAD.map((item) => (
+                <CardInfoTipoA
+                  titulo={ item[propriedadesCard.estabelecimento] }
+                  indicador={ item[propriedadesCard.quantidade] }
+                  indice={ item[propriedadesCard.difAnterior] }
+                  indiceSimbolo={ item[propriedadesCard.simbolo] }
+                  indiceDescricao={ item[propriedadesCard.descricao] }
+                  key={ `${item.id}-${item[propriedadesCard.difAnterior]}` }
+                />
+              ))
+            }
+            proporcao='3-3-3-3'
+          />
+        </>
+        : <Spinner theme='ColorSM' />
+      }
+    </>
+  );
+};
+
+export default CardsResumoEstabelecimentos;

--- a/components/CardsResumoEstabelecimentos/CardsResumoEstabelecimentos.jsx
+++ b/components/CardsResumoEstabelecimentos/CardsResumoEstabelecimentos.jsx
@@ -9,22 +9,28 @@ const CardsResumoEstabelecimentos = ({
   indiceSimbolo,
   indiceDescricao
 }) => {
-  const estabelecimentosLinhaDePerfilGeral = useMemo(() => {
+  const dadosLinhaDePerfilGeral = useMemo(() => {
     const dadosFiltrados = dados.filter((item) => item.estabelecimento_linha_perfil === 'Geral');
 
-    return ordenarCrescentePorPropriedadeDeTexto(
-      dadosFiltrados,
-      'estabelecimento'
-    );
+    return dadosFiltrados.length !== 0
+      ? {
+        nomeLinhaDePerfil: dadosFiltrados[0].estabelecimento_linha_perfil,
+        nomeMes: dadosFiltrados[0].nome_mes,
+        estabelecimentos: ordenarCrescentePorPropriedadeDeTexto(dadosFiltrados, 'estabelecimento')
+      }
+      : {};
   }, [dados]);
 
-  const estabelecimentosLinhaDePerfilAD = useMemo(() => {
+  const dadosLinhaDePerfilAD = useMemo(() => {
     const dadosFiltrados = dados.filter((item) => item.estabelecimento_linha_perfil === 'Álcool e outras drogas');
 
-    return ordenarCrescentePorPropriedadeDeTexto(
-      dadosFiltrados,
-      'estabelecimento'
-    );
+    return dadosFiltrados.length !== 0
+      ? {
+        nomeLinhaDePerfil: dadosFiltrados[0].estabelecimento_linha_perfil,
+        nomeMes: dadosFiltrados[0].nome_mes,
+        estabelecimentos: ordenarCrescentePorPropriedadeDeTexto(dadosFiltrados, 'estabelecimento')
+      }
+      : {};
   }, [dados]);
 
   return (
@@ -32,13 +38,13 @@ const CardsResumoEstabelecimentos = ({
       { dados.length !== 0
         ? <>
           <GraficoInfo
-            titulo={ `CAPS ${estabelecimentosLinhaDePerfilGeral[0].estabelecimento_linha_perfil}` }
-            descricao={ `Dados de ${estabelecimentosLinhaDePerfilGeral[0].nome_mes}` }
+            titulo={ `CAPS ${dadosLinhaDePerfilGeral.nomeLinhaDePerfil}` }
+            descricao={ `Dados de ${dadosLinhaDePerfilGeral.nomeMes}` }
           />
 
           <Grid12Col
             items={
-              estabelecimentosLinhaDePerfilGeral.map((item) => (
+              dadosLinhaDePerfilGeral.estabelecimentos.map((item) => (
                 <CardInfoTipoA
                   titulo={ item[propriedades.estabelecimento] }
                   indicador={ item[propriedades.quantidade] }
@@ -53,13 +59,13 @@ const CardsResumoEstabelecimentos = ({
           />
 
           <GraficoInfo
-            titulo={ `CAPS ${estabelecimentosLinhaDePerfilAD[0].estabelecimento_linha_perfil}` }
-            descricao={ `Dados de ${estabelecimentosLinhaDePerfilAD[0].nome_mes}` }
+            titulo={ `CAPS ${dadosLinhaDePerfilAD.nomeLinhaDePerfil}` }
+            descricao={ `Dados de ${dadosLinhaDePerfilAD.nomeMes}` }
           />
 
           <Grid12Col
             items={
-              estabelecimentosLinhaDePerfilAD.map((item) => (
+              dadosLinhaDePerfilAD.estabelecimentos.map((item) => (
                 <CardInfoTipoA
                   titulo={ item[propriedades.estabelecimento] }
                   indicador={ item[propriedades.quantidade] }

--- a/components/CardsResumoEstabelecimentos/CardsResumoEstabelecimentos.jsx
+++ b/components/CardsResumoEstabelecimentos/CardsResumoEstabelecimentos.jsx
@@ -1,32 +1,35 @@
 import { CardInfoTipoA, GraficoInfo, Grid12Col, Spinner } from '@impulsogov/design-system';
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { ordenarCrescentePorPropriedadeDeTexto } from '../../utils/ordenacao';
 
 const CardsResumoEstabelecimentos = ({
-  resumo,
-  propriedadesCard
+  dados,
+  propriedades,
+  indiceSimbolo,
+  indiceDescricao
 }) => {
   const estabelecimentosLinhaDePerfilGeral = useMemo(() => {
-    const dadosFiltrados = resumo.filter((item) => item.estabelecimento_linha_perfil === 'Geral');
+    const dadosFiltrados = dados.filter((item) => item.estabelecimento_linha_perfil === 'Geral');
 
     return ordenarCrescentePorPropriedadeDeTexto(
       dadosFiltrados,
       'estabelecimento'
     );
-  }, [resumo]);
+  }, [dados]);
 
   const estabelecimentosLinhaDePerfilAD = useMemo(() => {
-    const dadosFiltrados = resumo.filter((item) => item.estabelecimento_linha_perfil === 'Álcool e outras drogas');
+    const dadosFiltrados = dados.filter((item) => item.estabelecimento_linha_perfil === 'Álcool e outras drogas');
 
     return ordenarCrescentePorPropriedadeDeTexto(
       dadosFiltrados,
       'estabelecimento'
     );
-  }, [resumo]);
+  }, [dados]);
 
   return (
     <>
-      { resumo.length !== 0
+      { dados.length !== 0
         ? <>
           <GraficoInfo
             titulo={ `CAPS ${estabelecimentosLinhaDePerfilGeral[0].estabelecimento_linha_perfil}` }
@@ -37,12 +40,12 @@ const CardsResumoEstabelecimentos = ({
             items={
               estabelecimentosLinhaDePerfilGeral.map((item) => (
                 <CardInfoTipoA
-                  titulo={ item[propriedadesCard.estabelecimento] }
-                  indicador={ item[propriedadesCard.quantidade] }
-                  indice={ item[propriedadesCard.difAnterior] }
-                  indiceSimbolo={ item[propriedadesCard.simbolo] }
-                  indiceDescricao={ item[propriedadesCard.descricao] }
-                  key={ `${item.id}-${item[propriedadesCard.difAnterior]}` }
+                  titulo={ item[propriedades.estabelecimento] }
+                  indicador={ item[propriedades.quantidade] }
+                  indice={ item[propriedades.difAnterior] }
+                  indiceSimbolo={ indiceSimbolo }
+                  indiceDescricao={ indiceDescricao }
+                  key={ `${item.id}-${item[propriedades.difAnterior]}` }
                 />
               ))
             }
@@ -58,12 +61,12 @@ const CardsResumoEstabelecimentos = ({
             items={
               estabelecimentosLinhaDePerfilAD.map((item) => (
                 <CardInfoTipoA
-                  titulo={ item[propriedadesCard.estabelecimento] }
-                  indicador={ item[propriedadesCard.quantidade] }
-                  indice={ item[propriedadesCard.difAnterior] }
-                  indiceSimbolo={ item[propriedadesCard.simbolo] }
-                  indiceDescricao={ item[propriedadesCard.descricao] }
-                  key={ `${item.id}-${item[propriedadesCard.difAnterior]}` }
+                  titulo={ item[propriedades.estabelecimento] }
+                  indicador={ item[propriedades.quantidade] }
+                  indice={ item[propriedades.difAnterior] }
+                  indiceSimbolo={ indiceSimbolo }
+                  indiceDescricao={ indiceDescricao }
+                  key={ `${item.id}-${item[propriedades.difAnterior]}` }
                 />
               ))
             }
@@ -74,6 +77,22 @@ const CardsResumoEstabelecimentos = ({
       }
     </>
   );
+};
+
+CardsResumoEstabelecimentos.defaultProps = {
+  indiceSimbolo: '',
+  indiceDescricao: '',
+};
+
+CardsResumoEstabelecimentos.propTypes = {
+  dados: PropTypes.array.isRequired,
+  propriedades: PropTypes.shape({
+    estabelecimento: PropTypes.string,
+    quantidade: PropTypes.string,
+    difAnterior: PropTypes.string,
+  }).isRequired,
+  indiceSimbolo: PropTypes.string,
+  indiceDescricao: PropTypes.string,
 };
 
 export default CardsResumoEstabelecimentos;

--- a/components/CardsResumoEstabelecimentos/index.js
+++ b/components/CardsResumoEstabelecimentos/index.js
@@ -1,0 +1,5 @@
+import CardsResumoEstabelecimentos from './CardsResumoEstabelecimentos';
+
+export {
+  CardsResumoEstabelecimentos
+};

--- a/pages/caps/novosusuarios/index.js
+++ b/pages/caps/novosusuarios/index.js
@@ -226,9 +226,11 @@ const NovoUsuario = () => {
         fonte='Fonte: RAAS/SIASUS - Elaboração Impulso Gov'
       />
 
-      <GraficoInfo
-        descricao={ `Última competência disponível: ${nomeUltimoMes}` }
-      />
+      { nomeUltimoMes &&
+        <GraficoInfo
+          descricao={ `Última competência disponível: ${nomeUltimoMes}` }
+        />
+      }
 
       { resumoNovosUsuarios.length !== 0
         ? (resumoNovosUsuarios.map(({ linhaPerfil, usuariosPorEstabelecimento, nomeMes }) => (

--- a/pages/caps/novosusuarios/index.js
+++ b/pages/caps/novosusuarios/index.js
@@ -1,7 +1,6 @@
-import { CardInfoTipoA, GraficoInfo, Grid12Col, Spinner, TituloSmallTexto } from '@impulsogov/design-system';
+import { GraficoInfo, Spinner, TituloSmallTexto } from '@impulsogov/design-system';
 import { useSession } from 'next-auth/react';
-import { useCallback, useEffect, useState } from 'react';
-import { v1 as uuidv1 } from 'uuid';
+import { useEffect, useState } from 'react';
 import { TabelaGraficoDonut } from '../../../components/Tabelas';
 import GraficoGeneroPorFaixaEtaria from '../../../components/Graficos/GeneroPorFaixaEtaria';
 import { redirectHomeNotLooged } from '../../../helpers/RedirectHome';
@@ -13,6 +12,7 @@ import styles from '../Caps.module.css';
 import { FiltroCompetencia, FiltroTexto } from '../../../components/Filtros';
 import {FILTRO_PERIODO_MULTI_DEFAULT, FILTRO_ESTABELECIMENTO_DEFAULT} from '../../../constants/FILTROS';
 import { GraficoCondicaoUsuarios, GraficoDonut } from '../../../components/Graficos';
+import { CardsResumoEstabelecimentos } from '../../../components/CardsResumoEstabelecimentos';
 
 export function getServerSideProps(ctx) {
   const redirect = redirectHomeNotLooged(ctx);
@@ -73,49 +73,12 @@ const NovoUsuario = () => {
         item.estabelecimento !== 'Todos' && item.estabelecimento_linha_perfil !== 'Todos'
       ));
 
-      setResumoNovosUsuarios(agregarPorLinhaDePerfil(resumoPorEstabelecimentoELinhaPerfil));
+      setResumoNovosUsuarios(resumoPorEstabelecimentoELinhaPerfil);
     };
 
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
-
-  const agregarPorLinhaDePerfil = useCallback((dados) => {
-    const usuariosAgregados = [];
-
-    dados.forEach((item) => {
-      const {
-        estabelecimento,
-        nome_mes: nomeMes,
-        estabelecimento_linha_perfil: linhaPerfil,
-        usuarios_novos: usuariosNovos,
-        dif_usuarios_novos_anterior: diferencaMesAnterior
-      } = item;
-
-      const linhaPerfilEncontrada = usuariosAgregados
-        .find((item) => item.linhaPerfil === linhaPerfil);
-
-      if (!linhaPerfilEncontrada) {
-        usuariosAgregados.push({
-          nomeMes,
-          linhaPerfil,
-          usuariosPorEstabelecimento: [{
-            estabelecimento,
-            usuariosNovos,
-            diferencaMesAnterior
-          }]
-        });
-      } else {
-        linhaPerfilEncontrada.usuariosPorEstabelecimento.push({
-          estabelecimento,
-          usuariosNovos,
-          diferencaMesAnterior
-        });
-      }
-    });
-
-    return usuariosAgregados;
   }, []);
 
   useEffect(() => {
@@ -232,33 +195,15 @@ const NovoUsuario = () => {
         />
       }
 
-      { resumoNovosUsuarios.length !== 0
-        ? (resumoNovosUsuarios.map(({ linhaPerfil, usuariosPorEstabelecimento, nomeMes }) => (
-          <>
-            <GraficoInfo
-              titulo={ `CAPS ${linhaPerfil}` }
-              descricao={ `Dados de ${nomeMes}` }
-            />
-
-            <Grid12Col
-              items={
-                usuariosPorEstabelecimento.map((item) => (
-                  <CardInfoTipoA
-                    titulo={ item.estabelecimento }
-                    indicador={ item.usuariosNovos }
-                    indice={ item.diferencaMesAnterior }
-                    indiceDescricao='últ. mês'
-                    key={ uuidv1() }
-                  />
-                ))
-              }
-              proporcao='3-3-3-3'
-            />
-          </>
-        ))
-        )
-        : <Spinner theme='ColorSM' />
-      }
+      <CardsResumoEstabelecimentos
+        dados={ resumoNovosUsuarios }
+        propriedades={{
+          estabelecimento: 'estabelecimento',
+          quantidade: 'usuarios_novos',
+          difAnterior: 'dif_usuarios_novos_anterior',
+        }}
+        indiceDescricao='últ. mês'
+      />
 
       <GraficoInfo
         titulo='Histórico Temporal'

--- a/pages/caps/novosusuarios/index.js
+++ b/pages/caps/novosusuarios/index.js
@@ -60,7 +60,7 @@ const NovoUsuario = () => {
       const dadosFiltradosResumo = await obterResumoNovosUsuarios({
         municipioIdSus: session?.user.municipio_id_ibge,
         periodos: 'Último período',
-        linhas_de_idade: 'Todos',
+        estabelecimento_linha_idade: 'Todos',
       });
 
       const resumoGeral = dadosFiltradosResumo.find((item) => (
@@ -197,8 +197,8 @@ const NovoUsuario = () => {
       obterResumoNovosUsuarios({
         municipioIdSus: session?.user.municipio_id_ibge,
         estabelecimentos: filtroEstabelecimentoHistorico.value,
-        linhas_de_perfil: 'Todos',
-        linhas_de_idade: 'Todos',
+        estabelecimento_linha_perfil: 'Todos',
+        estabelecimento_linha_idade: 'Todos',
       }).then((dadosFiltrados) => {
         setNovosUsuariosHistorico(dadosFiltrados);
         setLoadingHistorico(false);

--- a/pages/caps/perfildousuario/index.js
+++ b/pages/caps/perfildousuario/index.js
@@ -1,6 +1,6 @@
 import { CardInfoTipoA, GraficoInfo, Grid12Col, Spinner, TituloSmallTexto } from '@impulsogov/design-system';
 import { useSession } from 'next-auth/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { redirectHomeNotLooged } from '../../../helpers/RedirectHome';
 import styles from '../Caps.module.css';
 import GraficoGeneroPorFaixaEtaria from '../../../components/Graficos/GeneroPorFaixaEtaria';
@@ -143,16 +143,12 @@ const PerfilUsuario = () => {
     }
   }, [session?.user.municipio_id_ibge, filtroPeriodoCardsETabela.value]);
 
-  const periodoExtensoPerfilPorEstabelecimento = useMemo(() => {
-    if (loadingCardsETabela) {
-      return '';
-    } else {
-      const { nome_mes: mes, competencia } = perfilPorEstabelecimento[0];
-      const [ano] = `${competencia}`.split('-');
+  const obterPeriodoExtensoPerfilPorEstabelecimento = useCallback(() => {
+    const { nome_mes: mes, competencia } = perfilPorEstabelecimento[0];
+    const [ano] = `${competencia}`.split('-');
 
-      return `${mes} de ${ano}`;
-    }
-  }, [loadingCardsETabela, perfilPorEstabelecimento]);
+    return `${mes} de ${ano}`;
+  }, [perfilPorEstabelecimento]);
 
   return (
     <div>
@@ -235,7 +231,10 @@ const PerfilUsuario = () => {
 
       <GraficoInfo
         titulo='Detalhamento por estabelecimento'
-        descricao={ `Dados de ${periodoExtensoPerfilPorEstabelecimento}` }
+        descricao={ loadingCardsETabela
+          ? ''
+          :`Dados de ${obterPeriodoExtensoPerfilPorEstabelecimento()}`
+        }
       />
 
       { loadingCardsETabela

--- a/pages/caps/perfildousuario/index.js
+++ b/pages/caps/perfildousuario/index.js
@@ -6,7 +6,7 @@ import styles from '../Caps.module.css';
 import GraficoGeneroPorFaixaEtaria from '../../../components/Graficos/GeneroPorFaixaEtaria';
 import { TabelaGraficoDonut, TabelaDetalhamentoPorCaps } from '../../../components/Tabelas';
 import GraficoRacaECor from '../../../components/Graficos/RacaECor';
-import { getEstabelecimentos, getPerfilUsuariosPorEstabelecimento, getPeriodos, getUsuariosAtivosPorCID, getUsuariosAtivosPorCondicao, getUsuariosAtivosPorGeneroEIdade, getUsuariosAtivosPorRacaECor } from '../../../requests/caps';
+import { getEstabelecimentos, obterPerfilUsuariosPorEstabelecimento, getPeriodos, getUsuariosAtivosPorCID, getUsuariosAtivosPorCondicao, getUsuariosAtivosPorGeneroEIdade, getUsuariosAtivosPorRacaECor, getPerfilUsuariosPorEstabelecimento } from '../../../requests/caps';
 import { FiltroCompetencia, FiltroTexto } from '../../../components/Filtros';
 import {FILTRO_PERIODO_DEFAULT, FILTRO_ESTABELECIMENTO_DEFAULT} from '../../../constants/FILTROS';
 import { GraficoCondicaoUsuarios, GraficoDonut } from '../../../components/Graficos';
@@ -28,6 +28,7 @@ const PerfilUsuario = () => {
   const [usuariosPorRacaECor, setUsuariosPorRacaECor] = useState([]);
   const [usuariosPorCID, setUsuariosPorCID] = useState([]);
   const [perfilPorEstabelecimento, setPerfilPorEstabelecimento] = useState([]);
+  const [nomeUltimoMes, setNomeUltimoMes] = useState('');
   const [filtroEstabelecimentoCID, setFiltroEstabelecimentoCID] = useState(FILTRO_ESTABELECIMENTO_DEFAULT);
   const [filtroCompetenciaCID, setFiltroCompetenciaCID] = useState(FILTRO_PERIODO_DEFAULT);
   const [filtroEstabelecimentoGenero, setFiltroEstabelecimentoGenero] = useState(FILTRO_ESTABELECIMENTO_DEFAULT);
@@ -52,6 +53,14 @@ const PerfilUsuario = () => {
 
       getPerfilUsuariosPorEstabelecimento(session?.user.municipio_id_ibge)
         .then((dados) => setPerfilPorEstabelecimento(dados));
+
+      obterPerfilUsuariosPorEstabelecimento({
+        municipioIdSus: session?.user.municipio_id_ibge,
+        estabelecimentos: 'Todos',
+        periodos: 'Último período',
+        linhas_de_perfil: 'Todos',
+        linhas_de_idade: 'Todos',
+      }).then((dados) => setNomeUltimoMes(dados[0].nome_mes));
     }
   }, []);
 
@@ -99,6 +108,7 @@ const PerfilUsuario = () => {
       });
     }
   }, [session?.user.municipio_id_ibge, filtroEstabelecimentoGenero.value, filtroCompetenciaGenero.value]);
+
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {
       setLoadingRaca(true);
@@ -221,13 +231,9 @@ const PerfilUsuario = () => {
         Usuários inativos: Usuários que não tiveram nenhum procedimento registrado no serviço há mais de 3 meses.'
       />
 
-      { perfilPorEstabelecimento.length !== 0
-        ? <GraficoInfo
-          descricao={ `Última competência disponível: ${encontrarDadosGeraisPorPeriodo(perfilPorEstabelecimento, 'Último período').nome_mes
-          }` }
-        />
-        : <Spinner theme='ColorSM' />
-      }
+      <GraficoInfo
+        descricao={ `Última competência disponível: ${nomeUltimoMes}` }
+      />
 
       <GraficoInfo
         titulo='Panorama geral'

--- a/pages/caps/perfildousuario/index.js
+++ b/pages/caps/perfildousuario/index.js
@@ -57,8 +57,8 @@ const PerfilUsuario = () => {
         municipioIdSus: session?.user.municipio_id_ibge,
         estabelecimentos: 'Todos',
         periodos: 'Último período',
-        linhas_de_perfil: 'Todos',
-        linhas_de_idade: 'Todos',
+        estabelecimento_linha_perfil: 'Todos',
+        estabelecimento_linha_idade: 'Todos',
       }).then((dadoFiltrado) => setNomeUltimoMes(dadoFiltrado[0].nome_mes));
     }
   }, []);
@@ -130,8 +130,8 @@ const PerfilUsuario = () => {
       obterPerfilUsuariosPorEstabelecimento({
         municipioIdSus: session?.user.municipio_id_ibge,
         periodos: filtroPeriodoCardsETabela.value,
-        linhas_de_perfil: 'Todos',
-        linhas_de_idade: 'Todos',
+        estabelecimento_linha_perfil: 'Todos',
+        estabelecimento_linha_idade: 'Todos',
       }).then((dadosFiltrados) => {
         const dadosPorEstabelecimento = dadosFiltrados.filter((item) => item.estabelecimento !== 'Todos');
         const totalEstabelecimentos = dadosFiltrados.find((item) => item.estabelecimento === 'Todos');

--- a/pages/caps/perfildousuario/index.js
+++ b/pages/caps/perfildousuario/index.js
@@ -176,9 +176,11 @@ const PerfilUsuario = () => {
         Usuários inativos: Usuários que não tiveram nenhum procedimento registrado no serviço há mais de 3 meses.'
       />
 
-      <GraficoInfo
-        descricao={ `Última competência disponível: ${nomeUltimoMes}` }
-      />
+      { nomeUltimoMes &&
+        <GraficoInfo
+          descricao={ `Última competência disponível: ${nomeUltimoMes}` }
+        />
+      }
 
       <GraficoInfo
         titulo='Panorama geral'

--- a/pages/caps/perfildousuario/index.js
+++ b/pages/caps/perfildousuario/index.js
@@ -1,12 +1,12 @@
 import { CardInfoTipoA, GraficoInfo, Grid12Col, Spinner, TituloSmallTexto } from '@impulsogov/design-system';
 import { useSession } from 'next-auth/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { redirectHomeNotLooged } from '../../../helpers/RedirectHome';
 import styles from '../Caps.module.css';
 import GraficoGeneroPorFaixaEtaria from '../../../components/Graficos/GeneroPorFaixaEtaria';
 import { TabelaGraficoDonut, TabelaDetalhamentoPorCaps } from '../../../components/Tabelas';
 import GraficoRacaECor from '../../../components/Graficos/RacaECor';
-import { getEstabelecimentos, obterPerfilUsuariosPorEstabelecimento, getPeriodos, getUsuariosAtivosPorCID, getUsuariosAtivosPorCondicao, getUsuariosAtivosPorGeneroEIdade, getUsuariosAtivosPorRacaECor, getPerfilUsuariosPorEstabelecimento } from '../../../requests/caps';
+import { getEstabelecimentos, obterPerfilUsuariosPorEstabelecimento, getPeriodos, getUsuariosAtivosPorCID, getUsuariosAtivosPorCondicao, getUsuariosAtivosPorGeneroEIdade, getUsuariosAtivosPorRacaECor } from '../../../requests/caps';
 import { FiltroCompetencia, FiltroTexto } from '../../../components/Filtros';
 import {FILTRO_PERIODO_DEFAULT, FILTRO_ESTABELECIMENTO_DEFAULT} from '../../../constants/FILTROS';
 import { GraficoCondicaoUsuarios, GraficoDonut } from '../../../components/Graficos';
@@ -28,6 +28,7 @@ const PerfilUsuario = () => {
   const [usuariosPorRacaECor, setUsuariosPorRacaECor] = useState([]);
   const [usuariosPorCID, setUsuariosPorCID] = useState([]);
   const [perfilPorEstabelecimento, setPerfilPorEstabelecimento] = useState([]);
+  const [panoramaGeral, setPanoramaGeral] = useState(null);
   const [nomeUltimoMes, setNomeUltimoMes] = useState('');
   const [filtroEstabelecimentoCID, setFiltroEstabelecimentoCID] = useState(FILTRO_ESTABELECIMENTO_DEFAULT);
   const [filtroCompetenciaCID, setFiltroCompetenciaCID] = useState(FILTRO_PERIODO_DEFAULT);
@@ -37,11 +38,12 @@ const PerfilUsuario = () => {
   const [filtroCompetenciaRacaCor, setFiltroCompetenciaRacaCor] = useState(FILTRO_PERIODO_DEFAULT);
   const [filtroEstabelecimentoUsuariosAtivos, setFiltroEstabelecimentoUsuariosAtivos] = useState(FILTRO_ESTABELECIMENTO_DEFAULT);
   const [filtroCompetenciaUsuariosAtivos, setFiltroCompetenciaUsuariosAtivos] = useState(FILTRO_PERIODO_DEFAULT);
-  const [filtroPeriodoPanorama, setFiltroPeriodoPanorama] = useState(FILTRO_PERIODO_DEFAULT);
+  const [filtroPeriodoCardsETabela, setFiltroPeriodoCardsETabela] = useState(FILTRO_PERIODO_DEFAULT);
   const [loadingCID, setLoadingCID] = useState(false);
   const [loadingGenero, setLoadingGenero] = useState(false);
   const [loadingCondicao, setLoadingCondicao] = useState(false);
   const [loadingRaca, setLoadingRaca] = useState(false);
+  const [loadingCardsETabela, setLoadingCardsETabela] = useState(true);
 
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {
@@ -51,16 +53,13 @@ const PerfilUsuario = () => {
       getPeriodos(session?.user.municipio_id_ibge, 'usuarios_ativos_perfil')
         .then((dados) => setCompetencias(dados));
 
-      getPerfilUsuariosPorEstabelecimento(session?.user.municipio_id_ibge)
-        .then((dados) => setPerfilPorEstabelecimento(dados));
-
       obterPerfilUsuariosPorEstabelecimento({
         municipioIdSus: session?.user.municipio_id_ibge,
         estabelecimentos: 'Todos',
         periodos: 'Último período',
         linhas_de_perfil: 'Todos',
         linhas_de_idade: 'Todos',
-      }).then((dados) => setNomeUltimoMes(dados[0].nome_mes));
+      }).then((dadoFiltrado) => setNomeUltimoMes(dadoFiltrado[0].nome_mes));
     }
   }, []);
 
@@ -124,90 +123,36 @@ const PerfilUsuario = () => {
     }
   }, [session?.user.municipio_id_ibge, filtroEstabelecimentoRacaCor.value, filtroCompetenciaRacaCor.value]);
 
-  const encontrarDadosGeraisPorPeriodo = (dados, filtroPeriodo) => {
-    return dados.find((item) =>
-      item.estabelecimento === 'Todos'
-      && item.estabelecimento_linha_perfil === 'Todos'
-      && item.estabelecimento_linha_idade === 'Todos'
-      && item.periodo === filtroPeriodo
-    );
-  };
+  useEffect(() => {
+    if (session?.user.municipio_id_ibge) {
+      setLoadingCardsETabela(true);
 
-  const filtrarDadosEstabelecimentosPorPeriodo = (dados, filtroPeriodo) => {
-    return dados.filter((item) =>
-      item.estabelecimento_linha_perfil === 'Todos'
-      && item.estabelecimento_linha_idade === 'Todos'
-      && item.periodo === filtroPeriodo
-      && item.estabelecimento !== 'Todos'
-    );
-  };
+      obterPerfilUsuariosPorEstabelecimento({
+        municipioIdSus: session?.user.municipio_id_ibge,
+        periodos: filtroPeriodoCardsETabela.value,
+        linhas_de_perfil: 'Todos',
+        linhas_de_idade: 'Todos',
+      }).then((dadosFiltrados) => {
+        const dadosPorEstabelecimento = dadosFiltrados.filter((item) => item.estabelecimento !== 'Todos');
+        const totalEstabelecimentos = dadosFiltrados.find((item) => item.estabelecimento === 'Todos');
 
-  const getCardsPanoramaGeral = (perfilDeEstabelecimentos, filtroPeriodo) => {
-    const perfilTodosEstabelecimentos = encontrarDadosGeraisPorPeriodo(
-      perfilDeEstabelecimentos,
-      filtroPeriodo
-    );
+        setPanoramaGeral(totalEstabelecimentos);
+        setPerfilPorEstabelecimento(dadosPorEstabelecimento);
+        setLoadingCardsETabela(false);
+      });
+    }
+  }, [session?.user.municipio_id_ibge, filtroPeriodoCardsETabela.value]);
 
-    const {
-      ativos_mes: ativosMes,
-      dif_ativos_mes_anterior: difAtivosMesAnterior,
-      ativos_3meses: ativos3Meses,
-      dif_ativos_3meses_anterior: difAtivos3MesesAnterior,
-      tornandose_inativos: tornandoInativos,
-      dif_tornandose_inativos_anterior: difTornandoInativosAnterior
-    } = perfilTodosEstabelecimentos;
+  const periodoExtensoPerfilPorEstabelecimento = useMemo(() => {
+    if (loadingCardsETabela) {
+      return '';
+    } else {
+      const { nome_mes: mes, competencia } = perfilPorEstabelecimento[0];
+      const [ano] = `${competencia}`.split('-');
 
-    return (
-      <Grid12Col
-        proporcao='4-4-4'
-        items={ [
-          <>
-            {
-              <CardInfoTipoA
-                fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
-                indicador={ ativos3Meses }
-                indice={ difAtivos3MesesAnterior }
-                indiceDescricao='últ. mês'
-                titulo='Usuários ativos'
-                tooltip='Usuários que tiveram algum procedimento registrado em BPA-i ou RAAS (exceto acolhimento inicial) nos três meses anteriores ao mês de referência'
-              />
-            }
-          </>,
-          <>
-            {
-              <CardInfoTipoA
-                fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
-                indicador={ ativosMes }
-                indice={ difAtivosMesAnterior }
-                indiceDescricao='últ. mês'
-                titulo='Frequentaram no mês'
-                tooltip='Usuários que tiveram algum procedimento registrado em BPA-i ou RAAS (exceto acolhimento inicial) durante o mês de referÊncia'
-              />
-            }
-          </>,
-          <>
-            {
-              <CardInfoTipoA
-                fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
-                indicador={ tornandoInativos }
-                indice={ difTornandoInativosAnterior }
-                indiceDescricao='últ. mês'
-                titulo='Tornaram-se inativos'
-                tooltip='Usuários que, no mês de referência, completaram três meses sem ter procedimentos registrados em BPA-i ou RAAS (exceto acolhimento inicial)'
-              />
-            }
-          </>,
-        ] }
-      />
-    );
-  };
-
-  const obterPeriodoPorExtenso = useCallback((dados, periodo) => {
-    const { nome_mes: mes, competencia } = dados.find((dado) => dado.periodo === periodo);
-    const [ano] = `${competencia}`.split('-');
-
-    return `${mes} de ${ano}`;
-  }, []);
+      return `${mes} de ${ano}`;
+    }
+  }, [loadingCardsETabela, perfilPorEstabelecimento]);
 
   return (
     <div>
@@ -239,42 +184,63 @@ const PerfilUsuario = () => {
         titulo='Panorama geral'
       />
 
-      { perfilPorEstabelecimento.length !== 0
-        ? (
-          <>
-            <FiltroCompetencia
-              width={'50%'}
-              dados = {perfilPorEstabelecimento}
-              valor = {filtroPeriodoPanorama}
-              setValor = {setFiltroPeriodoPanorama}
-              isMulti = {false}
-              label = {'Competência'}
-            />
+      { competencias.length !== 0 &&
+        <FiltroCompetencia
+          width='50%'
+          dados={ competencias }
+          valor={ filtroPeriodoCardsETabela }
+          setValor={ setFiltroPeriodoCardsETabela }
+          isMulti={ false }
+          label='Competência'
+        />
+      }
 
-            {
-              getCardsPanoramaGeral(
-                perfilPorEstabelecimento,
-                filtroPeriodoPanorama.value
-              )
-            }
-          </>
-        )
-        : <Spinner theme='ColorSM' />
+      { loadingCardsETabela
+        ? <Spinner theme='ColorSM' />
+        : <Grid12Col
+          proporcao='4-4-4'
+          items={ [
+            <CardInfoTipoA
+              key={ `${panoramaGeral.id}-${panoramaGeral.ativos_3meses}` }
+              fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
+              indicador={ panoramaGeral.ativos_3meses }
+              indice={ panoramaGeral.dif_ativos_3meses_anterior }
+              indiceDescricao='últ. mês'
+              titulo='Usuários ativos'
+              tooltip='Usuários que tiveram algum procedimento registrado em BPA-i ou RAAS (exceto acolhimento inicial) nos três meses anteriores ao mês de referência'
+            />,
+            <CardInfoTipoA
+              key={ `${panoramaGeral.id}-${panoramaGeral.ativos_mes}` }
+              fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
+              indicador={ panoramaGeral.ativos_mes }
+              indice={ panoramaGeral.dif_ativos_mes_anterior }
+              indiceDescricao='últ. mês'
+              titulo='Frequentaram no mês'
+              tooltip='Usuários que tiveram algum procedimento registrado em BPA-i ou RAAS (exceto acolhimento inicial) durante o mês de referÊncia'
+            />,
+            <CardInfoTipoA
+              key={ `${panoramaGeral.id}-${panoramaGeral.tornandose_inativos}` }
+              fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
+              indicador={ panoramaGeral.tornandose_inativos }
+              indice={ panoramaGeral.dif_tornandose_inativos_anterior }
+              indiceDescricao='últ. mês'
+              titulo='Tornaram-se inativos'
+              tooltip='Usuários que, no mês de referência, completaram três meses sem ter procedimentos registrados em BPA-i ou RAAS (exceto acolhimento inicial)'
+            />
+          ] }
+        />
       }
 
       <GraficoInfo
         titulo='Detalhamento por estabelecimento'
-        descricao={ perfilPorEstabelecimento.length !== 0 && `Dados de ${obterPeriodoPorExtenso(perfilPorEstabelecimento, filtroPeriodoPanorama.value)
-        }` }
+        descricao={ `Dados de ${periodoExtensoPerfilPorEstabelecimento}` }
       />
 
-      { perfilPorEstabelecimento.length !== 0
-        ? <TabelaDetalhamentoPorCaps
-          usuariosPorCaps={ filtrarDadosEstabelecimentosPorPeriodo(
-            perfilPorEstabelecimento, filtroPeriodoPanorama.value
-          ) }
+      { loadingCardsETabela
+        ? <Spinner theme='ColorSM' />
+        : <TabelaDetalhamentoPorCaps
+          usuariosPorCaps={ perfilPorEstabelecimento }
         />
-        : <Spinner theme='ColorSM' />
       }
 
       <div className={ styles.MensagemTabela }>

--- a/pages/caps/procedimentosporusuarios/index.js
+++ b/pages/caps/procedimentosporusuarios/index.js
@@ -135,14 +135,14 @@ const ProcedimentosPorUsuarios = () => {
       }
 
       <CardsResumoEstabelecimentos
-        resumo={ resumoPorEstabelecimento }
-        propriedadesCard={{
+        dados={ resumoPorEstabelecimento }
+        propriedades={{
           estabelecimento: 'estabelecimento',
           quantidade: 'procedimentos_por_usuario',
           difAnterior: 'dif_procedimentos_por_usuario_anterior_perc',
-          simbolo: '%',
-          descricao: 'últ. mês',
         }}
+        indiceSimbolo='%'
+        indiceDescricao='últ. mês'
       />
 
       <GraficoInfo

--- a/pages/caps/procedimentosporusuarios/index.js
+++ b/pages/caps/procedimentosporusuarios/index.js
@@ -1,14 +1,13 @@
-import { CardInfoTipoA, GraficoInfo, Grid12Col, Spinner, TituloSmallTexto } from "@impulsogov/design-system";
+import { GraficoInfo, Spinner, TituloSmallTexto } from "@impulsogov/design-system";
 import { useSession } from "next-auth/react";
-import { useEffect, useMemo, useState } from "react";
-import { v1 as uuidv1 } from "uuid";
+import { useEffect, useState } from "react";
 import { FiltroCompetencia, FiltroTexto } from '../../../components/Filtros';
 import { GraficoHistoricoTemporal, GraficoProcedimentosPorTempoServico } from "../../../components/Graficos";
 import { FILTRO_ESTABELECIMENTO_DEFAULT, FILTRO_PERIODO_MULTI_DEFAULT } from '../../../constants/FILTROS';
 import { redirectHomeNotLooged } from "../../../helpers/RedirectHome";
-import { getEstabelecimentos, getPeriodos, getProcedimentosPorEstabelecimento, obterProcedimentosPorTempoServico } from "../../../requests/caps";
-import { ordenarCrescentePorPropriedadeDeTexto } from "../../../utils/ordenacao";
+import { getEstabelecimentos, getPeriodos, obterProcedimentosPorEstabelecimento, obterProcedimentosPorTempoServico } from "../../../requests/caps";
 import styles from "../Caps.module.css";
+import { CardsResumoEstabelecimentos } from "../../../components/CardsResumoEstabelecimentos";
 
 export function getServerSideProps(ctx) {
   const redirect = redirectHomeNotLooged(ctx);
@@ -22,16 +21,35 @@ const ProcedimentosPorUsuarios = () => {
   const { data: session } = useSession();
   const [procedimentosPorEstabelecimento, setProcedimentosPorEstabelecimento] = useState([]);
   const [procedimentosPorTempoServico, setProcedimentosPorTempoServico] = useState([]);
+  const [resumoPorEstabelecimento, setResumoPorEstabelecimento] = useState([]);
+  const [nomeUltimoMes, setNomeUltimoMes] = useState('');
   const [filtroEstabelecimentoProcedimento, setFiltroEstabelecimentoProcedimento] = useState(FILTRO_ESTABELECIMENTO_DEFAULT);
   const [filtroPeriodoProcedimento, setFiltroPeriodoProcedimento] = useState(FILTRO_PERIODO_MULTI_DEFAULT);
   const [filtroEstabelecimentoHistorico, setFiltroEstabelecimentoHistorico] = useState(FILTRO_ESTABELECIMENTO_DEFAULT);
   const [loadingProcedimentosPorTempoServico, setLoadingProcedimentosPorTempoServico] = useState(true);
+  const [loadingHistorico, setLoadingHistorico] = useState(true);
   const [estabelecimentos, setEstabelecimentos] = useState([]);
   const [periodos, setPeriodos] = useState([]);
 
   useEffect(() => {
     const getDados = async (municipioIdSus) => {
-      setProcedimentosPorEstabelecimento(await getProcedimentosPorEstabelecimento(municipioIdSus));
+      const dadosFiltradosResumo = await obterProcedimentosPorEstabelecimento({
+        municipioIdSus: session?.user.municipio_id_ibge,
+        periodos: 'Último período',
+        estabelecimento_linha_idade: 'Todos',
+      });
+
+      const resumoGeral = dadosFiltradosResumo.find((item) => (
+        item.estabelecimento === 'Todos' && item.estabelecimento_linha_perfil === 'Todos'
+      ));
+
+      setNomeUltimoMes(resumoGeral.nome_mes);
+
+      const resumoPorEstabelecimentoELinhaPerfil = dadosFiltradosResumo.filter((item) => (
+        item.estabelecimento !== 'Todos' && item.estabelecimento_linha_perfil !== 'Todos'
+      ));
+
+      setResumoPorEstabelecimento(resumoPorEstabelecimentoELinhaPerfil);
       setEstabelecimentos(await getEstabelecimentos(
         municipioIdSus,
         "procedimentos_usuarios_tempo_servico"
@@ -72,104 +90,23 @@ const ProcedimentosPorUsuarios = () => {
     filtroPeriodoProcedimento
   ]);
 
-  const agregarPorLinhaPerfil = (procedimentos) => {
-    const procedimentosAgregados = [];
+  useEffect(() => {
+    if (session?.user.municipio_id_ibge) {
+      setLoadingHistorico(true);
 
-    procedimentos.forEach((procedimento) => {
-      const {
-        estabelecimento,
-        nome_mes: nomeMes,
-        estabelecimento_linha_perfil: linhaPerfil,
-        procedimentos_por_usuario: procedimentosPorUsuario,
-        dif_procedimentos_por_usuario_anterior_perc: difPorcentagemProcedimentosAnterior
-      } = procedimento;
+      obterProcedimentosPorEstabelecimento({
+        municipioIdSus: session?.user.municipio_id_ibge,
+        estabelecimentos: filtroEstabelecimentoHistorico.value,
+        estabelecimento_linha_idade: 'Todos',
+        estabelecimento_linha_perfil: 'Todos',
+      }).then((dadosFiltrados) => setProcedimentosPorEstabelecimento(dadosFiltrados));
 
-      const linhaPerfilEncontrada = procedimentosAgregados
-        .find((item) => item.linhaPerfil === linhaPerfil);
-
-      if (!linhaPerfilEncontrada) {
-        procedimentosAgregados.push({
-          nomeMes,
-          linhaPerfil,
-          procedimentosPorEstabelecimento: [{
-            estabelecimento,
-            procedimentosPorUsuario,
-            difPorcentagemProcedimentosAnterior
-          }]
-        });
-      } else {
-        linhaPerfilEncontrada.procedimentosPorEstabelecimento.push({
-          estabelecimento,
-          procedimentosPorUsuario,
-          difPorcentagemProcedimentosAnterior
-        });
-      }
-    });
-
-    return procedimentosAgregados;
-  };
-
-  const getCardsProcedimentosPorEstabelecimento = (procedimentos) => {
-    const procedimentosPorEstabelecimentoUltimoPeriodo = procedimentos
-      .filter(({
-        periodo,
-        estabelecimento,
-        estabelecimento_linha_perfil: linhaPerfil,
-        estabelecimento_linha_idade: linhaIdade
-      }) =>
-        periodo === 'Último período'
-        && estabelecimento !== 'Todos'
-        && linhaPerfil !== 'Todos'
-        && linhaIdade === 'Todos'
-      );
-
-    const procedimentosAgregados = agregarPorLinhaPerfil(procedimentosPorEstabelecimentoUltimoPeriodo);
-
-    const cardsProcedimentosPorEstabelecimento = procedimentosAgregados.map(({
-      linhaPerfil, procedimentosPorEstabelecimento, nomeMes
-    }) => {
-      const procedimentosOrdenados = ordenarCrescentePorPropriedadeDeTexto(
-        procedimentosPorEstabelecimento,
-        'estabelecimento'
-      );
-
-      return (
-        <>
-          <GraficoInfo
-            titulo={ `CAPS ${linhaPerfil}` }
-            descricao={ `Dados de ${nomeMes}` }
-          />
-
-          <Grid12Col
-            items={
-              procedimentosOrdenados.map((item) => (
-                <CardInfoTipoA
-                  titulo={ item.estabelecimento }
-                  indicador={ item.procedimentosPorUsuario }
-                  indice={ item.difPorcentagemProcedimentosAnterior }
-                  indiceSimbolo='%'
-                  indiceDescricao='últ. mês'
-                  key={ uuidv1() }
-                />
-              ))
-            }
-            proporcao='3-3-3-3'
-          />
-        </>
-      );
-    });
-
-    return cardsProcedimentosPorEstabelecimento;
-  };
-
-  const procedimentosPorEstabelecimentoFiltrados = useMemo(() => {
-    return procedimentosPorEstabelecimento
-      .filter((item) =>
-        item.estabelecimento === filtroEstabelecimentoHistorico.value
-        && item.estabelecimento_linha_perfil === 'Todos'
-        && item.estabelecimento_linha_idade === 'Todos'
-      );
-  }, [procedimentosPorEstabelecimento, filtroEstabelecimentoHistorico.value]);
+      setLoadingHistorico(false);
+    }
+  }, [
+    session?.user.municipio_id_ibge,
+    filtroEstabelecimentoHistorico.value
+  ]);
 
   return (
     <div>
@@ -191,51 +128,46 @@ const ProcedimentosPorUsuarios = () => {
         fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
       />
 
-      { procedimentosPorEstabelecimento.length !== 0
-        ? (
-          <>
-            <GraficoInfo
-              descricao={ `Última competência disponível: ${procedimentosPorEstabelecimento
-                .find((item) =>
-                  item.estabelecimento === 'Todos'
-                  && item.estabelecimento_linha_perfil === 'Todos'
-                  && item.estabelecimento_linha_idade === 'Todos'
-                  && item.periodo === 'Último período'
-                )
-                .nome_mes
-                }` }
-            />
-
-            { getCardsProcedimentosPorEstabelecimento(procedimentosPorEstabelecimento) }
-          </>
-        )
-        : <Spinner theme='ColorSM' />
+      { nomeUltimoMes &&
+        <GraficoInfo
+          descricao={ `Última competência disponível: ${nomeUltimoMes}` }
+        />
       }
+
+      <CardsResumoEstabelecimentos
+        resumo={ resumoPorEstabelecimento }
+        propriedadesCard={{
+          estabelecimento: 'estabelecimento',
+          quantidade: 'procedimentos_por_usuario',
+          difAnterior: 'dif_procedimentos_por_usuario_anterior_perc',
+          simbolo: '%',
+          descricao: 'últ. mês',
+        }}
+      />
 
       <GraficoInfo
         titulo='Histórico Temporal'
         fonte='Fonte: BPA-i e RAAS/SIASUS - Elaboração Impulso Gov'
       />
-      { procedimentosPorEstabelecimento.length !== 0
-        ? (
-          <>
-            <FiltroTexto
-              width={ '50%' }
-              dados={ procedimentosPorEstabelecimento }
-              valor={ filtroEstabelecimentoHistorico }
-              setValor={ setFiltroEstabelecimentoHistorico }
-              label={ 'Estabelecimento' }
-              propriedade={ 'estabelecimento' }
-            />
 
-            <GraficoHistoricoTemporal
-              dados={ procedimentosPorEstabelecimentoFiltrados }
-              textoTooltip={ filtroEstabelecimentoHistorico.value }
-              propriedade='procedimentos_por_usuario'
-              loading={ false }
-            />
-          </>
-        )
+      { estabelecimentos.length !== 0 &&
+        <FiltroTexto
+          width={ '50%' }
+          dados={ estabelecimentos }
+          valor={ filtroEstabelecimentoHistorico }
+          setValor={ setFiltroEstabelecimentoHistorico }
+          label={ 'Estabelecimento' }
+          propriedade={ 'estabelecimento' }
+        />
+      }
+
+      { procedimentosPorEstabelecimento.length !== 0
+        ? <GraficoHistoricoTemporal
+          dados={ procedimentosPorEstabelecimento }
+          textoTooltip={ filtroEstabelecimentoHistorico.value }
+          propriedade='procedimentos_por_usuario'
+          loading={ loadingHistorico }
+        />
         : <Spinner theme='ColorSM' />
       }
 

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -29,6 +29,36 @@ export const getPerfilUsuariosPorEstabelecimento = async (municipioIdSus) => {
   }
 };
 
+export const obterPerfilUsuariosPorEstabelecimento = async ({
+  municipioIdSus,
+  estabelecimentos,
+  periodos,
+  linhas_de_perfil,
+  linhas_de_idade
+}) => {
+  try {
+    let endpoint = "/usuarios/perfil/por-estabelecimento?municipio_id_sus=" + municipioIdSus;
+    const parametrosOpcionais = {
+      periodos,
+      estabelecimentos,
+      linhas_de_perfil,
+      linhas_de_idade
+    };
+
+    for (const parametro in parametrosOpcionais) {
+      if (parametrosOpcionais[parametro] !== undefined) {
+        endpoint += `&${parametro}=${parametrosOpcionais[parametro]}`;
+      }
+    }
+
+    const { data } = await axiosInstance.get(endpoint);
+
+    return data;
+  } catch (error) {
+    console.log('error', error.response.data);
+  }
+};
+
 export const getResumoNovosUsuarios = async (municipioIdSus) => {
   try {
     const endpoint = "/usuarios/novosresumo?municipio_id_sus=" + municipioIdSus;

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -101,9 +101,27 @@ export const getAtendimentosPorCaps = async (municipioIdSus) => {
   }
 };
 
-export const getProcedimentosPorEstabelecimento = async (municipioIdSus) => {
+export const obterProcedimentosPorEstabelecimento = async ({
+  municipioIdSus,
+  estabelecimentos,
+  periodos,
+  estabelecimento_linha_perfil,
+  estabelecimento_linha_idade
+}) => {
   try {
     const endpoint = "/procedimentos_por_usuario_estabelecimentos?municipio_id_sus=" + municipioIdSus;
+    const parametrosOpcionais = {
+      periodos,
+      estabelecimentos,
+      estabelecimento_linha_perfil,
+      estabelecimento_linha_idade
+    };
+
+    for (const parametro in parametrosOpcionais) {
+      if (parametrosOpcionais[parametro] !== undefined) {
+        endpoint += `&${parametro}=${parametrosOpcionais[parametro]}`;
+      }
+    }
 
     const { data } = await axiosInstance.get(endpoint);
 

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -17,17 +17,17 @@ export const getPerfilUsuarios = async (municipioIdSus) => {
   }
 };
 
-export const getPerfilUsuariosPorEstabelecimento = async (municipioIdSus) => {
-  try {
-    const endpoint = "/usuarios/perfilestabelecimento?municipio_id_sus=" + municipioIdSus;
+// export const getPerfilUsuariosPorEstabelecimento = async (municipioIdSus) => {
+//   try {
+//     const endpoint = "/usuarios/perfilestabelecimento?municipio_id_sus=" + municipioIdSus;
 
-    const { data } = await axiosInstance.get(endpoint);
+//     const { data } = await axiosInstance.get(endpoint);
 
-    return data;
-  } catch (error) {
-    console.log('error', error.response.data);
-  }
-};
+//     return data;
+//   } catch (error) {
+//     console.log('error', error.response.data);
+//   }
+// };
 
 export const obterPerfilUsuariosPorEstabelecimento = async ({
   municipioIdSus,

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -21,16 +21,16 @@ export const obterPerfilUsuariosPorEstabelecimento = async ({
   municipioIdSus,
   estabelecimentos,
   periodos,
-  linhas_de_perfil,
-  linhas_de_idade
+  estabelecimento_linha_perfil,
+  estabelecimento_linha_idade
 }) => {
   try {
     let endpoint = "/usuarios/perfil/por-estabelecimento?municipio_id_sus=" + municipioIdSus;
     const parametrosOpcionais = {
       periodos,
       estabelecimentos,
-      linhas_de_perfil,
-      linhas_de_idade
+      estabelecimento_linha_perfil,
+      estabelecimento_linha_idade
     };
 
     for (const parametro in parametrosOpcionais) {
@@ -51,16 +51,16 @@ export const obterResumoNovosUsuarios = async ({
   municipioIdSus,
   estabelecimentos,
   periodos,
-  linhas_de_perfil,
-  linhas_de_idade
+  estabelecimento_linha_perfil,
+  estabelecimento_linha_idade
 }) => {
   try {
     let endpoint = "/usuarios/novos/resumo?municipio_id_sus=" + municipioIdSus;
     const parametrosOpcionais = {
       periodos,
       estabelecimentos,
-      linhas_de_perfil,
-      linhas_de_idade
+      estabelecimento_linha_perfil,
+      estabelecimento_linha_idade
     };
 
     for (const parametro in parametrosOpcionais) {

--- a/requests/caps.js
+++ b/requests/caps.js
@@ -17,18 +17,6 @@ export const getPerfilUsuarios = async (municipioIdSus) => {
   }
 };
 
-// export const getPerfilUsuariosPorEstabelecimento = async (municipioIdSus) => {
-//   try {
-//     const endpoint = "/usuarios/perfilestabelecimento?municipio_id_sus=" + municipioIdSus;
-
-//     const { data } = await axiosInstance.get(endpoint);
-
-//     return data;
-//   } catch (error) {
-//     console.log('error', error.response.data);
-//   }
-// };
-
 export const obterPerfilUsuariosPorEstabelecimento = async ({
   municipioIdSus,
   estabelecimentos,
@@ -59,9 +47,27 @@ export const obterPerfilUsuariosPorEstabelecimento = async ({
   }
 };
 
-export const getResumoNovosUsuarios = async (municipioIdSus) => {
+export const obterResumoNovosUsuarios = async ({
+  municipioIdSus,
+  estabelecimentos,
+  periodos,
+  linhas_de_perfil,
+  linhas_de_idade
+}) => {
   try {
-    const endpoint = "/usuarios/novosresumo?municipio_id_sus=" + municipioIdSus;
+    let endpoint = "/usuarios/novos/resumo?municipio_id_sus=" + municipioIdSus;
+    const parametrosOpcionais = {
+      periodos,
+      estabelecimentos,
+      linhas_de_perfil,
+      linhas_de_idade
+    };
+
+    for (const parametro in parametrosOpcionais) {
+      if (parametrosOpcionais[parametro] !== undefined) {
+        endpoint += `&${parametro}=${parametrosOpcionais[parametro]}`;
+      }
+    }
 
     const { data } = await axiosInstance.get(endpoint);
 


### PR DESCRIPTION
### Objetivos
- Criar novas funções de requisição, passando filtros de estabelecimentos, periodos, estabelecimento_linha_perfil e estabelecimento_linha_perfil para os endpoints:
  - `/usuarios/perfil/por-estabelecimento`
  - `/usuarios/novos/resumo`
  - `/procedimentos_por_usuario_estabelecimentos`
- Usar as novas requisições nas páginas:
  - Perfil de usuário
  - Novos usuários
  - Procedimentos por usuário
- Criar componente para os CardsResumoEstabelecimentos e usá-lo nas páginas de Novos usuários e Procedimentos por usuário
  - Este componente foi criado porque havia um padrão entre os cards exibidos em ambas as páginas, logo fazia sentido torná-los num componente