### PR TITLE
Fix: "Gráficos recarregam ao trocar de aba"

### DIFF
--- a/pages/caps/index.js
+++ b/pages/caps/index.js
@@ -1,7 +1,6 @@
 import { ButtonLight, PanelSelectorSM, TituloTexto } from "@impulsogov/design-system";
 import { useRouter } from 'next/router';
 import { useEffect, useState } from "react";
-import { v1 as uuidv1 } from 'uuid';
 import { redirectHomeNotLooged } from "../../helpers/RedirectHome";
 import style from "../duvidas/Duvidas.module.css";
 import AtendimentoIndividual from "./atendimentoindividuais";
@@ -68,13 +67,13 @@ export default function Paineis() {
           setActiveTitleTabIndex: setActiveTitleTabIndex
         } }
         components={ [[
-          <Resumo key={ uuidv1() } />,
-          <PerfilUsuario key={ uuidv1() } />,
-          <NovoUsuario key={ uuidv1() } />,
-          <TaxaAbandono key={ uuidv1() } />,
-          <AtendimentoIndividual key={ uuidv1() } />,
-          <ProcedimentosPorUsuarios key={ uuidv1() } />,
-          <Producao key={ uuidv1() } />,
+          <Resumo key={ 'resumo-caps' } />,
+          <PerfilUsuario key={ 'perfilusuario' } />,
+          <NovoUsuario key={ 'novousuario' } />,
+          <TaxaAbandono key={ 'taxaabandono' } />,
+          <AtendimentoIndividual key={ 'atendimentoindividual' } />,
+          <ProcedimentosPorUsuarios key={ 'procedimentosporusuarios' } />,
+          <Producao key={ 'producao' } />,
         ]] }
         subtitles={ [
           [

--- a/pages/cuidado-compartilhado/index.js
+++ b/pages/cuidado-compartilhado/index.js
@@ -1,7 +1,6 @@
 import { ButtonLight, PanelSelectorSM, TituloTexto } from "@impulsogov/design-system";
 import { useRouter } from 'next/router';
 import { useEffect, useState } from "react";
-import { v1 as uuidv1 } from 'uuid';
 import { redirectHomeNotLooged } from "../../helpers/RedirectHome";
 import style from "../duvidas/Duvidas.module.css";
 import ApsAmbulatorio from "./aps-ambulatorio";
@@ -64,10 +63,10 @@ const Index = ({ }) => {
           setActiveTitleTabIndex: setActiveTitleTabIndex
         } }
         components={ [[
-          <Resumo key={ uuidv1() }></Resumo>,
-          <ApsCaps key={ uuidv1() }></ApsCaps>,
-          <ApsAmbulatorio key={ uuidv1() }></ApsAmbulatorio>,
-          <RapsHospitalar key={ uuidv1() }></RapsHospitalar>
+          <Resumo key={ 'resumo-cuidado-compartilhado' }></Resumo>,
+          <ApsCaps key={ 'apscaps' }></ApsCaps>,
+          <ApsAmbulatorio key={ 'apsambulatorio' }></ApsAmbulatorio>,
+          <RapsHospitalar key={ 'rapshospitalar' }></RapsHospitalar>
         ]] }
         subtitles={ [
           [


### PR DESCRIPTION
### Descrição
Os gráficos das páginas de CAPS e Cuidado compartilhado são recarregados toda vez que o usuário troca de aba.
Isso acontece porque usávamos uma função geradora de uuid como chave nos componentes do seletor do painel.

### Objetivo
Esse PR visa resolver o bug mudando a chave desses componentes para uma string contendo o título de cada página em caixa baixa e sem espaços. 

Em páginas que possuem o nome repetido, foi adicionado hífen + o nome da página. Por exemplo: A página "Resumo" dentro de "Cuidado compartilhado"  ficou `<Resumo key={ 'resumo-cuidado-compartilhado' }></Resumo>`
