### PR TITLE
[Outros RAPS] Corrige filtro da tabela de atendimentos por profissional

### DIFF
--- a/components/Filtros/SelectMultiplo.jsx
+++ b/components/Filtros/SelectMultiplo.jsx
@@ -22,6 +22,8 @@ const SelectMultiplo = ({
     label: labelAllOption
   };
 
+  const hasOnlyOneOption = options.length === 1;
+
   useEffect(() => {
     if (isDefaultAllOption && showAllOption) {
       setValor(options);
@@ -35,10 +37,10 @@ const SelectMultiplo = ({
     valueRef.current.some(({ value }) => value === option.value) ||
       isSelectAllSelected();
 
-  const getOptions = () => showAllOption ? [selectAllOption, ...options] : options;
+  const getOptions = () => showAllOption && !hasOnlyOneOption ? [selectAllOption, ...options] : options;
 
   const getValue = () =>
-    isSelectAllSelected() ? [selectAllOption] : valor;
+    isSelectAllSelected() && !hasOnlyOneOption ? [selectAllOption] : valor;
 
   const handleChange = (newValue, actionMeta) => {
     const { action, option, removedValue } = actionMeta;

--- a/pages/outros-raps/ambulatorio/index.js
+++ b/pages/outros-raps/ambulatorio/index.js
@@ -354,7 +354,6 @@ const Ambulatorio = () => {
               label={ 'Competência' }
               isMulti
               showAllOption
-              isDefaultAllOption
             />
           </div>
           <TabelaAtendimentosPorProfissional


### PR DESCRIPTION
<!--
TEMPLATE DE PULL REQUEST (PR)

- O QUE É?
  - Um modelo que traz os tópicos necessários para descrever um PR.

- QUAL O OBJETIVO?
  - Padronizar as descrições dos PRs nesse repositório e garantir que toda pessoa que os acesse tenha informações necessárias para entendê-los e usá-los.

- COMO USAR?
  - Siga os comentários de instrução presentes em cada seção abaixo para preenchê-las corretamente.

OBS: Não é necessário apagar os comentários, eles não aparecerão na descrição de seu PR.
-->

### Descrição
<!-- Descreva aqui o contexto de criação do PR, o que motivou a implementação dessas mudanças -->
A tabela de Atendimentos por profissional, na página de Outros RAPS <> Ambulatório, não possui totalização dos estabelecimentos feita direto no banco de dados, logo o filtro de estabelecimento dessa tabela não exibia a opção Todos normalmente. Para incluir a opção de totalização, foi criada no front-end do filtro múltiplo a opção Todos, que, ao ser selecionada, seleciona todos os estabelecimentos disponíveis de uma só vez e somente a palavra Todos é exibida no valor do filtro, ao invés do nome de cada estabelecimento. 

![image](https://github.com/ImpulsoGov/SaudeMental/assets/45800622/d744aa10-9f4f-4ff6-8561-422ac20c4220)

Recentemente, percebeu-se que, quando o filtro só possuía uma opção de estabelecimentos, sempre que esse único estabelecimento estava selecionado, o filtro só exibia a palavra Todos no seu valor, ao invés do nome do estabelecimento. E, ao remover a opção de totalização, não era possível selecionar apenas o estabelecimento sem que a opção Todos fosse selecionada junto, o que dificultava o entendimento por parte dos usuários.

![image](https://github.com/ImpulsoGov/SaudeMental/assets/45800622/fe45fd73-be55-4764-8aff-3e3812746802)

Além disso, o filtro de competência da tabela começa com todas as competências selecionadas, o que faz com que profissionais de muitos antigos e que já não fazem mais parte do CAPS apareçam na renderização inicial da tabela.

### Objetivos
<!-- Descreva aqui as mudanças que esse PR se destina a fazer -->
- Fazer com que, quando houver apenas uma opção de estabelecimento no filtro da tabela, a opção Todos não seja exibida
- Fazer com que o filtro de competência da tabela comece apenas com o **Último período** selecionado

### Como validar
<!--
Descreva aqui o que a pessoa revisora desse PR deve fazer para validar as alterações feitas, ex:
- Interaja com os filtros do gráfico selecionando múltiplas competências e/ou estabelecimentos (tente selecionar estabelecimentos com nomes compostos) para observar se erros inesperados acontecem.
- Remova todos os valores dos filtros e observe se é exibida a mensagem "Sem dados nessa competência".
- Compare os valores exibidos pelo gráfico na versão local com os valores exibidos pelo gráfico na versão de produção do site.

Tente pensar no caminho natural ao usar a funcionalidade e também nos casos extremos.
-->
- Cheque se apenas o Último período está selecionado no filtro de competência da tabela quando ela é exibida na tela
- Cheque se, para o município de Quixeramobim (que possui apenas uma opção de estabelecimento nessa tabela), a opção Todos não é mais mostrada no filtro de estabelecimento da tabela de Atendimentos por profissional em Outros RAPS <> Ambulatório
- Cheque se ainda é possível interagir com os filtros
- Cheque se, ao interagir com os filtros, os dados da tabela são alterados
- Cheque se, para o município de Recife (que possui mais de uma opção de estabelecimento nessa tabela), o filtro mostra a opção Todos e ela funciona como esperado:
  - quando selecionada, seleciona todos os estabelecimentos disponíveis
  - quando removida, nenhum estabelecimento permanece selecionado
  - quando selecionada e em seguida é removido apenas 1 estabelecimentos, os outros permanecem selecionados
  - é possível selecionar apenas um estabelecimento sem que a opção Todos seja selecionada junto

### Mudanças de configuração
<!--
Descreva aqui as mudanças na configuração da aplicação (adição/mudança de variáveis de ambiente), caso tenham sido feitas.

OBS: não insira aqui o valor das variáveis de ambiente, apenas inclua o nome dela, onde deve ser definida/alterada e como a pessoa pode acessar seu valor, ex: "Foi criada a variável de ambiente ENV_VAR pelo motivo X. Seu valor se encontra no Bitwarden e ela deve ser adicionada no arquivo /caminho/do/arquivo para execução local *e na Vercel para execução em produção.*".

*: o ideal é que a pessoa que criou a variável de ambiente faça sua inclusão/edição no local onde a aplicação é hospedada, portanto adicione o trecho entre * na frase de exemplo acima caso você não tenha permissão para fazer a inclusão/edição.
 -->
Esse PR não faz mudanças de configuração da aplicação.

### Checklist
<!-- Marque os checkboxes abaixo à medida em que as tarefas são feitas e garanta que todas elas sejam realizadas antes de mergear o PR -->

- [x] Validar a funcionalidade com o time
