### PR TITLE
[CAPS] Remove filtro por linha de idade na página de Procedimentos por Usuários

### DIFF
--- a/pages/caps/procedimentosporusuarios/index.js
+++ b/pages/caps/procedimentosporusuarios/index.js
@@ -72,6 +72,43 @@ const ProcedimentosPorUsuarios = () => {
     filtroPeriodoProcedimento
   ]);
 
+  const agregarPorLinhaPerfil = (procedimentos) => {
+    const procedimentosAgregados = [];
+
+    procedimentos.forEach((procedimento) => {
+      const {
+        estabelecimento,
+        nome_mes: nomeMes,
+        estabelecimento_linha_perfil: linhaPerfil,
+        procedimentos_por_usuario: procedimentosPorUsuario,
+        dif_procedimentos_por_usuario_anterior_perc: difPorcentagemProcedimentosAnterior
+      } = procedimento;
+
+      const linhaPerfilEncontrada = procedimentosAgregados
+        .find((item) => item.linhaPerfil === linhaPerfil);
+
+      if (!linhaPerfilEncontrada) {
+        procedimentosAgregados.push({
+          nomeMes,
+          linhaPerfil,
+          procedimentosPorEstabelecimento: [{
+            estabelecimento,
+            procedimentosPorUsuario,
+            difPorcentagemProcedimentosAnterior
+          }]
+        });
+      } else {
+        linhaPerfilEncontrada.procedimentosPorEstabelecimento.push({
+          estabelecimento,
+          procedimentosPorUsuario,
+          difPorcentagemProcedimentosAnterior
+        });
+      }
+    });
+
+    return procedimentosAgregados;
+  };
+
   const getCardsProcedimentosPorEstabelecimento = (procedimentos) => {
     const procedimentosPorEstabelecimentoUltimoPeriodo = procedimentos
       .filter(({
@@ -83,20 +120,21 @@ const ProcedimentosPorUsuarios = () => {
         && estabelecimento !== 'Todos'
         && linhaPerfil !== 'Todos'
       );
+    const procedimentosAgregados = agregarPorLinhaPerfil(procedimentosPorEstabelecimentoUltimoPeriodo);
 
-    const cardsProcedimentosPorEstabelecimento = procedimentosPorEstabelecimentoUltimoPeriodo.map(({
-      estabelecimento_linha_perfil, nome_mes
+    const cardsProcedimentosPorEstabelecimento = procedimentosAgregados.map(({
+      linhaPerfil, procedimentosPorEstabelecimento, nomeMes
     }) => {
       const procedimentosOrdenados = ordenarCrescentePorPropriedadeDeTexto(
-        procedimentosPorEstabelecimentoUltimoPeriodo,
+        procedimentosPorEstabelecimento,
         'estabelecimento'
       );
 
       return (
         <>
           <GraficoInfo
-            titulo={ `CAPS ${estabelecimento_linha_perfil}` }
-            descricao={ `Dados de ${nome_mes}` }
+            titulo={ `CAPS ${linhaPerfil}` }
+            descricao={ `Dados de ${nomeMes}` }
           />
 
           <Grid12Col
@@ -104,11 +142,11 @@ const ProcedimentosPorUsuarios = () => {
               procedimentosOrdenados.map((item) => (
                 <CardInfoTipoA
                   titulo={ item.estabelecimento }
-                  indicador={ item.procedimentos_por_usuario }
-                  indice={ item.dif_procedimentos_por_usuario_anterior_perc }
+                  indicador={ item.procedimentosPorUsuario }
+                  indice={ item.difPorcentagemProcedimentosAnterior }
                   indiceSimbolo='%'
                   indiceDescricao='últ. mês'
-                  key={ item.id }
+                  key={ uuidv1() }
                 />
               ))
             }

--- a/pages/caps/procedimentosporusuarios/index.js
+++ b/pages/caps/procedimentosporusuarios/index.js
@@ -72,72 +72,31 @@ const ProcedimentosPorUsuarios = () => {
     filtroPeriodoProcedimento
   ]);
 
-  const agregarPorLinhaPerfil = (procedimentos) => {
-    const procedimentosAgregados = [];
-
-    procedimentos.forEach((procedimento) => {
-      const {
-        estabelecimento,
-        nome_mes: nomeMes,
-        estabelecimento_linha_perfil: linhaPerfil,
-        procedimentos_por_usuario: procedimentosPorUsuario,
-        dif_procedimentos_por_usuario_anterior_perc: difPorcentagemProcedimentosAnterior
-      } = procedimento;
-
-      const linhaPerfilEncontrada = procedimentosAgregados
-        .find((item) => item.linhaPerfil === linhaPerfil);
-
-      if (!linhaPerfilEncontrada) {
-        procedimentosAgregados.push({
-          nomeMes,
-          linhaPerfil,
-          procedimentosPorEstabelecimento: [{
-            estabelecimento,
-            procedimentosPorUsuario,
-            difPorcentagemProcedimentosAnterior
-          }]
-        });
-      } else {
-        linhaPerfilEncontrada.procedimentosPorEstabelecimento.push({
-          estabelecimento,
-          procedimentosPorUsuario,
-          difPorcentagemProcedimentosAnterior
-        });
-      }
-    });
-
-    return procedimentosAgregados;
-  };
-
   const getCardsProcedimentosPorEstabelecimento = (procedimentos) => {
     const procedimentosPorEstabelecimentoUltimoPeriodo = procedimentos
       .filter(({
         periodo,
         estabelecimento,
         estabelecimento_linha_perfil: linhaPerfil,
-        estabelecimento_linha_idade: linhaIdade
       }) =>
         periodo === 'Último período'
         && estabelecimento !== 'Todos'
         && linhaPerfil !== 'Todos'
-        && linhaIdade === 'Todos'
       );
 
-    const procedimentosAgregados = agregarPorLinhaPerfil(procedimentosPorEstabelecimentoUltimoPeriodo);
-
-    const cardsProcedimentosPorEstabelecimento = procedimentosAgregados.map(({
-      linhaPerfil, procedimentosPorEstabelecimento, nomeMes
+    const cardsProcedimentosPorEstabelecimento = procedimentosPorEstabelecimentoUltimoPeriodo.map(({
+      estabelecimento_linha_perfil, nome_mes
     }) => {
       const procedimentosOrdenados = ordenarCrescentePorPropriedadeDeTexto(
-        procedimentosPorEstabelecimento,
+        procedimentosPorEstabelecimentoUltimoPeriodo,
         'estabelecimento'
       );
 
       return (
         <>
           <GraficoInfo
-            titulo={ `CAPS ${linhaPerfil}` }
-            descricao={ `Dados de ${nomeMes}` }
+            titulo={ `CAPS ${estabelecimento_linha_perfil}` }
+            descricao={ `Dados de ${nome_mes}` }
           />
 
           <Grid12Col
@@ -145,11 +104,11 @@ const ProcedimentosPorUsuarios = () => {
               procedimentosOrdenados.map((item) => (
                 <CardInfoTipoA
                   titulo={ item.estabelecimento }
-                  indicador={ item.procedimentosPorUsuario }
-                  indice={ item.difPorcentagemProcedimentosAnterior }
+                  indicador={ item.procedimentos_por_usuario }
+                  indice={ item.dif_procedimentos_por_usuario_anterior_perc }
                   indiceSimbolo='%'
                   indiceDescricao='últ. mês'
-                  key={ uuidv1() }
+                  key={ item.id }
                 />
               ))
             }
@@ -166,8 +125,6 @@ const ProcedimentosPorUsuarios = () => {
     return procedimentosPorEstabelecimento
       .filter((item) =>
         item.estabelecimento === filtroEstabelecimentoHistorico.value
-        && item.estabelecimento_linha_perfil === 'Todos'
-        && item.estabelecimento_linha_idade === 'Todos'
       );
   }, [procedimentosPorEstabelecimento, filtroEstabelecimentoHistorico.value]);
 
@@ -198,12 +155,10 @@ const ProcedimentosPorUsuarios = () => {
               descricao={ `Última competência disponível: ${procedimentosPorEstabelecimento
                 .find((item) =>
                   item.estabelecimento === 'Todos'
-                  && item.estabelecimento_linha_perfil === 'Todos'
-                  && item.estabelecimento_linha_idade === 'Todos'
                   && item.periodo === 'Último período'
                 )
                 .nome_mes
-                }` }
+              }` }
             />
 
             { getCardsProcedimentosPorEstabelecimento(procedimentosPorEstabelecimento) }


### PR DESCRIPTION
<!--
TEMPLATE DE PULL REQUEST (PR)

- O QUE É?
  - Um modelo que traz os tópicos necessários para descrever um PR.

- QUAL O OBJETIVO?
  - Padronizar as descrições dos PRs nesse repositório e garantir que toda pessoa que os acesse tenha informações necessárias para entendê-los e usá-los.

- COMO USAR?
  - Siga os comentários de instrução presentes em cada seção abaixo para preenchê-las corretamente.

OBS: Não é necessário apagar os comentários, eles não aparecerão na descrição de seu PR.
-->

### Descrição
<!-- Descreva aqui o contexto de criação do PR, o que motivou a implementação dessas mudanças -->
Foram removidas da tabela  `caps_procedimentos_por_usuario_estabelecimento` do banco de dados as repetições causadas pela classificação de `estabelecimento_linha _idade` e` estabelecimento_linha_perfil`. A partir dessa alteração, foi necessário remover os filtros de linha idade e linha perfil aplicados nos cards e gráfico de Histórico Temporal que consumiam a mesma tabela `caps_procedimentos_por_usuario_estabelecimento` .


### Objetivos
<!-- Descreva aqui as mudanças que esse PR se destina a fazer -->
- Remover os filtros de linha idade.
- Remover os filtros de linha perfil.

### Como validar
<!--
Descreva aqui o que a pessoa revisora desse PR deve fazer para validar as alterações feitas, ex:
- Interaja com os filtros do gráfico selecionando múltiplas competências e/ou estabelecimentos (tente selecionar estabelecimentos com nomes compostos) para observar se erros inesperados acontecem.
- Remova todos os valores dos filtros e observe se é exibida a mensagem "Sem dados nessa competência".
- Compare os valores exibidos pelo gráfico na versão local com os valores exibidos pelo gráfico na versão de produção do site.

Tente pensar no caminho natural ao usar a funcionalidade e também nos casos extremos.

- Verifique se os cards estão sem repetição do mesmo estabelecimento.
- Verifique se o gráfico de Histórico Temporal não possui repetição de competências.

-->

### Mudanças de configuração
<!--
Descreva aqui as mudanças na configuração da aplicação (adição/mudança de variáveis de ambiente), caso tenham sido feitas.

OBS: não insira aqui o valor das variáveis de ambiente, apenas inclua o nome dela, onde deve ser definida/alterada e como a pessoa pode acessar seu valor, ex: "Foi criada a variável de ambiente ENV_VAR pelo motivo X. Seu valor se encontra no Bitwarden e ela deve ser adicionada no arquivo /caminho/do/arquivo para execução local *e na Vercel para execução em produção.*".

*: o ideal é que a pessoa que criou a variável de ambiente faça sua inclusão/edição no local onde a aplicação é hospedada, portanto adicione o trecho entre * na frase de exemplo acima caso você não tenha permissão para fazer a inclusão/edição.
 -->
Esse PR não faz modificações de configuração da aplicação.
### Checklist
<!-- Marque os checkboxes abaixo à medida em que as tarefas são feitas e garanta que todas elas sejam realizadas antes de mergear o PR -->

- [ ] Validar a funcionalidade com a Taí
