### PR TITLE
[PAINEL] Corrige dependências de useEffects

### DIFF
--- a/pages/caps/atendimentoindividuais/index.js
+++ b/pages/caps/atendimentoindividuais/index.js
@@ -61,7 +61,7 @@ const AtendimentoIndividual = () => {
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {
       setLoadingHistorico(true);

--- a/pages/caps/novosusuarios/index.js
+++ b/pages/caps/novosusuarios/index.js
@@ -79,7 +79,7 @@ const NovoUsuario = () => {
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {

--- a/pages/caps/perfildousuario/index.js
+++ b/pages/caps/perfildousuario/index.js
@@ -61,7 +61,7 @@ const PerfilUsuario = () => {
         estabelecimento_linha_idade: 'Todos',
       }).then((dadoFiltrado) => setNomeUltimoMes(dadoFiltrado[0].nome_mes));
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {

--- a/pages/caps/procedimentosporusuarios/index.js
+++ b/pages/caps/procedimentosporusuarios/index.js
@@ -60,7 +60,7 @@ const ProcedimentosPorUsuarios = () => {
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {

--- a/pages/caps/producao/index.js
+++ b/pages/caps/producao/index.js
@@ -62,7 +62,7 @@ const Producao = () => {
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   // prcedimentos por hora
   useEffect(() => {

--- a/pages/caps/resumo/index.js
+++ b/pages/caps/resumo/index.js
@@ -27,7 +27,7 @@ const Resumo = () => {
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   return (
     <div>

--- a/pages/caps/taxadeabandono/index.js
+++ b/pages/caps/taxadeabandono/index.js
@@ -56,7 +56,7 @@ const TaxaAbandono = () => {
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {

--- a/pages/cuidado-compartilhado/aps-ambulatorio/index.js
+++ b/pages/cuidado-compartilhado/aps-ambulatorio/index.js
@@ -39,7 +39,7 @@ const ApsAmbulatorio = () => {
         .then(result => setEncaminhamentosApsResumo(result[0]))
         .catch(error => console.log('error', error));
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   return (
     <div>

--- a/pages/cuidado-compartilhado/aps-caps/index.js
+++ b/pages/cuidado-compartilhado/aps-caps/index.js
@@ -63,7 +63,7 @@ const ApsCaps = () => {
         .catch(error => console.log('error', error));
 
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   return (
     <div>

--- a/pages/cuidado-compartilhado/raps-hospitalar/index.js
+++ b/pages/cuidado-compartilhado/raps-hospitalar/index.js
@@ -43,7 +43,7 @@ const RapsHospitalar = ({ }) => {
           setPeriodosECompetencias(periodosECompetencias);
         });
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   useEffect(() => {
     const filtradas = internacoesRapsAltas.filter(item => item.periodo === filtroPeriodoInternacoesRapsAltas.value);

--- a/pages/cuidado-compartilhado/resumo/index.js
+++ b/pages/cuidado-compartilhado/resumo/index.js
@@ -113,7 +113,7 @@ const Resumo = () => {
         .then(result => setInternacoesRapsAltas12m(result[0]))
         .catch(error => console.log('error', error));
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   const getPorcentagemAtendimentosNaoFeitos = (encaminhamentos) => {
     const { prop_atendimentos: propAtendimentos } = encaminhamentos

--- a/pages/outros-raps/ambulatorio/index.js
+++ b/pages/outros-raps/ambulatorio/index.js
@@ -54,7 +54,7 @@ const Ambulatorio = () => {
     if (session?.user.municipio_id_ibge && !municipioSemAmbulatorio && !municipioSemDadosAmbulatorio) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge, municipioSemAmbulatorio, municipioSemDadosAmbulatorio]);
 
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {

--- a/pages/outros-raps/consultorio-na-rua/index.js
+++ b/pages/outros-raps/consultorio-na-rua/index.js
@@ -37,7 +37,7 @@ const ConsultorioNaRua = () => {
     if (session?.user.municipio_id_ibge && !municipioSemConsultorioNaRua) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge]);
 
   const atendimentosFiltradosPorProducao = useMemo(() => {
     return atendimentos.filter(({ tipo_producao: tipoProducao }) => tipoProducao === filtroProducao.value);

--- a/pages/outros-raps/reducao-de-danos/index.js
+++ b/pages/outros-raps/reducao-de-danos/index.js
@@ -51,7 +51,7 @@ const ReducaoDeDanos = () => {
     if (session?.user.municipio_id_ibge && !municipioSemReducaoDanos) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge, municipioSemReducaoDanos]);
 
   useEffect(() => {
     if (session?.user.municipio_id_ibge) {

--- a/pages/outros-raps/resumo/index.js
+++ b/pages/outros-raps/resumo/index.js
@@ -55,7 +55,7 @@ const Resumo = () => {
     if (session?.user.municipio_id_ibge) {
       getDados(session?.user.municipio_id_ibge);
     }
-  }, []);
+  }, [session?.user.municipio_id_ibge, municipioSemCardsAmbulatorio, municipioSemCardsConsultorioNaRua, municipioSemCardsReducaoDanos]);
 
   const getDadosConsultorioNaRua = () => {
     return consultorioNaRua.find((item) =>


### PR DESCRIPTION
<!--
TEMPLATE DE PULL REQUEST (PR)

- O QUE É?
  - Um modelo que traz os tópicos necessários para descrever um PR.

- QUAL O OBJETIVO?
  - Padronizar as descrições dos PRs nesse repositório e garantir que toda pessoa que os acesse tenha informações necessárias para entendê-los e usá-los.

- COMO USAR?
  - Siga os comentários de instrução presentes em cada seção abaixo para preenchê-las corretamente.

OBS: Não é necessário apagar os comentários, eles não aparecerão na descrição de seu PR.
-->

### Descrição
<!-- Descreva aqui o contexto de criação do PR, o que motivou a implementação dessas mudanças -->
Recentemente, foi constatado que, ao recarregar as páginas da plataforma de saúde mental, os dados de alguns componentes das páginas eram perdidos e a API não era chamada novamente para puxar os dados desses componentes, fazendo com que ficassem carregando infinitamente.

Depois de investigar o problema, percebeu-se que os componentes que apresentavam esse comportamento após as páginas serem recarregadas eram aqueles cujos dados dependiam da execução de `useEffects` com o array de dependências vazio, ou seja, `useEffects` que só eram executados uma vez, apenas quando o componente da página era montado. Além disso, constatou-se que a causa desse problema era a ausência de uma dependência no array de dependências desses `useEffects`.

### Objetivos
<!-- Descreva aqui as mudanças que esse PR se destina a fazer -->
- Adicionar as dependências ausentes nos useEffects das páginas de CAPS, Outros serviços RAPS e Cuidado compartilhado de saúde mental.

### Como validar
<!--
Descreva aqui o que a pessoa revisora desse PR deve fazer para validar as alterações feitas, ex:
- Interaja com os filtros do gráfico selecionando múltiplas competências e/ou estabelecimentos (tente selecionar estabelecimentos com nomes compostos) para observar se erros inesperados acontecem.
- Remova todos os valores dos filtros e observe se é exibida a mensagem "Sem dados nessa competência".
- Compare os valores exibidos pelo gráfico na versão local com os valores exibidos pelo gráfico na versão de produção do site.

Tente pensar no caminho natural ao usar a funcionalidade e também nos casos extremos.
-->
- Cheque se as páginas listadas abaixo exibem corretamente todos os gráficos, filtros, cards e tabelas que possuem ao serem recarregadas:
  - [ ] Resumo <> CAPS
  - [ ] Perfil de usuário <> CAPS
  - [ ] Novos usuários <> CAPS
  - [ ] Taxa de não adesão <> CAPS
  - [ ] Atendimentos individuais <> CAPS
  - [ ] Procedimentos por usuário <> CAPS
  - [ ] Produção <> CAPS
  - [x] Ambulatório <> Outros RAPS
  - [x] Consultório na rua <> Outros RAPS
  - [x] Redução de danos <> Outros RAPS
  - [x] Resumo <> Outros RAPS
  - [x] Resumo <> Cuidado compartilhado
  - [x] APS e CAPS <> Cuidado compartilhado
  - [x] APS e Ambulatório <> Cuidado compartilhado
  - [x] RAPS e Atenção hospitalar <> Cuidado compartilhado

### Mudanças de configuração
<!--
Descreva aqui as mudanças na configuração da aplicação (adição/mudança de variáveis de ambiente), caso tenham sido feitas.

OBS: não insira aqui o valor das variáveis de ambiente, apenas inclua o nome dela, onde deve ser definida/alterada e como a pessoa pode acessar seu valor, ex: "Foi criada a variável de ambiente ENV_VAR pelo motivo X. Seu valor se encontra no Bitwarden e ela deve ser adicionada no arquivo /caminho/do/arquivo para execução local *e na Vercel para execução em produção.*".

*: o ideal é que a pessoa que criou a variável de ambiente faça sua inclusão/edição no local onde a aplicação é hospedada, portanto adicione o trecho entre * na frase de exemplo acima caso você não tenha permissão para fazer a inclusão/edição.
 -->
Esse PR não faz mudanças de configuração.

### Checklist
<!-- Marque os checkboxes abaixo à medida em que as tarefas são feitas e garanta que todas elas sejam realizadas antes de mergear o PR -->

- [ ] Validar a funcionalidade com o time
