### PR TITLE
[Cuidado-compartilhado] Adiciona condicional para renderização dos cards Atendidos na RAPS

### DIFF
--- a/pages/cuidado-compartilhado/resumo/index.js
+++ b/pages/cuidado-compartilhado/resumo/index.js
@@ -255,8 +255,16 @@ const Resumo = () => {
                 indicador={ internacoesRapsAdmissoes12m["internacoes_atendimento_raps_antes"] }
                 titulo="Atendidos na RAPS nos últimos 6 meses antes da Internação"
                 tooltip="Usuários que tiveram ao menos um procedimento RAAS registrado em serviços RAPS dentro dos 6 meses anteriores a sua internação na rede hospitalar"
-                porcentagemSim={ getPorcentagemInternacoesFeitas(internacoesRapsAdmissoesVertical) }
-                porcentagemNao={ getPorcentagemInternacoesNaoFeitas(internacoesRapsAdmissoesVertical) }
+                porcentagemSim={
+                  internacoesRapsAdmissoes12m["perc_internacoes_atendimento_raps_antes"] !== null
+                    ? getPorcentagemInternacoesFeitas(internacoesRapsAdmissoesVertical)
+                    : undefined
+                }
+                porcentagemNao={
+                  internacoesRapsAdmissoes12m["perc_internacoes_atendimento_raps_antes"] !== null
+                    ? getPorcentagemInternacoesNaoFeitas(internacoesRapsAdmissoesVertical)
+                    : undefined
+                }
               />
               : <Spinner theme="ColorSM" />
             }
@@ -270,8 +278,16 @@ const Resumo = () => {
                 indicador={ internacoesRapsAltas12m["altas_atendimento_raps_1m_apos"] }
                 titulo="Atendidos na RAPS até o mês seguinte à alta"
                 tooltip="Usuários que tiveram ao menos um procedimento RAAS registrado em serviços RAPS até o mês seguinte à alta de sua internação na rede hospitalar."
-                porcentagemSim={ getPorcentagemAltasFeitas(internacoesRapsAltasVertical) }
-                porcentagemNao={ getPorcentagemAltasNaoFeitas(internacoesRapsAltasVertical) }
+                porcentagemSim={
+                  internacoesRapsAdmissoes12m["perc_internacoes_atendimento_raps_antes"] !== null
+                    ? getPorcentagemAltasFeitas(internacoesRapsAltasVertical)
+                    : undefined
+                }
+                porcentagemNao={
+                  internacoesRapsAdmissoes12m["perc_internacoes_atendimento_raps_antes"] !== null
+                    ? getPorcentagemAltasNaoFeitas(internacoesRapsAltasVertical)
+                    : undefined
+                }
               />
               : <Spinner theme="ColorSM" />
             }


### PR DESCRIPTION
<!--
TEMPLATE DE PULL REQUEST (PR)

- O QUE É?
  - Um modelo que traz os tópicos necessários para descrever um PR.

- QUAL O OBJETIVO?
  - Padronizar as descrições dos PRs nesse repositório e garantir que toda pessoa que os acesse tenha informações necessárias para entendê-los e usá-los.

- COMO USAR?
  - Siga os comentários de instrução presentes em cada seção abaixo para preenchê-las corretamente.

OBS: Não é necessário apagar os comentários, eles não aparecerão na descrição de seu PR.
-->

### Descrição
<!-- Descreva aqui o contexto de criação do PR, o que motivou a implementação dessas mudanças -->
Esse PR visa implementar uma solução para o problema descrito nesse [card](https://www.notion.so/impulsogov/Bugs-e-Melhorias-t-cnicas-996bf3c49a8847bfbf8c1c2118af586a?p=11fb0775b4054e5e9164064540b9962d&pm=s).
Na página Resumo <> Cuidado-compartilhado, nos cards referentes a Cuidado compartilhado entre RAPS e Rede de Urgência e Emergência.
Esse problema acontecia no seguinte cenário: O número de atendidos na RAPS até o mês seguinte à alta é 0, e o número de pessoas que receberam alta de internações também é zero. Como não é possível realizar uma divisão por zero, a única porcentagem possível será NULL, não 0%. Manter o gráfico mostrando 0% é uma informação errada.

### Objetivos
<!-- Descreva aqui as mudanças que esse PR se destina a fazer -->

- Adicionar um desvio condicional para renderizar o gráfico de Atendidos na RAPS nos últimos 6 meses antes da Internação apenas se `perc_internacoes_atendimentos_raps_antes` for diferente de null. 
- Adicionar um desvio condicional para renderizar o gráfico de Atendidos na RAPS até o mês seguinte à alta apenas se `perc_internacoes_atendimentos_raps_antes` for diferente de null. 

### Como validar
<!--
Descreva aqui o que a pessoa revisora desse PR deve fazer para validar as alterações feitas, ex:
- Interaja com os filtros do gráfico selecionando múltiplas competências e/ou estabelecimentos (tente selecionar estabelecimentos com nomes compostos) para observar se erros inesperados acontecem.
- Remova todos os valores dos filtros e observe se é exibida a mensagem "Sem dados nessa competência".
- Compare os valores exibidos pelo gráfico na versão local com os valores exibidos pelo gráfico na versão de produção do site.

Tente pensar no caminho natural ao usar a funcionalidade e também nos casos extremos.
-->
Utilizando as credenciais do município Palmeiras dos Índios, verifique se os seguintes gráficos **não** são renderizados:
- [x] Atendidos na RAPS nos últimos 6 meses antes da Internação;
- [x] Atendidos na RAPS até o mês seguinte à alta;

Utilizando as credenciais do município Impulsolândia, verifique se os seguintes gráficos **são** renderizados: 
- [x] Atendidos na RAPS nos últimos 6 meses antes da Internação;
- [x] Atendidos na RAPS até o mês seguinte à alta;
### Mudanças de configuração
<!--
Descreva aqui as mudanças na configuração da aplicação (adição/mudança de variáveis de ambiente), caso tenham sido feitas.

OBS: não insira aqui o valor das variáveis de ambiente, apenas inclua o nome dela, onde deve ser definida/alterada e como a pessoa pode acessar seu valor, ex: "Foi criada a variável de ambiente ENV_VAR pelo motivo X. Seu valor se encontra no Bitwarden e ela deve ser adicionada no arquivo /caminho/do/arquivo para execução local *e na Vercel para execução em produção.*".

*: o ideal é que a pessoa que criou a variável de ambiente faça sua inclusão/edição no local onde a aplicação é hospedada, portanto adicione o trecho entre * na frase de exemplo acima caso você não tenha permissão para fazer a inclusão/edição.
 -->
Esse PR não implementa mudanças na configuração da aplicação.
### Checklist
<!-- Marque os checkboxes abaixo à medida em que as tarefas são feitas e garanta que todas elas sejam realizadas antes de mergear o PR -->

- [ ] Validar a funcionalidade com o time
