### PR TITLE
[HOME] Corrige alinhamento do título da seção de parceiros

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -74,32 +74,33 @@ export default function Home({res}) {
             },
           ]} />
         </section>
-
-        <Parcerias
-          parceiros={[
-            { alt: "parceiros", src: res[0].logos[4].logo.url, titulo: "Técnico e financeiro" },
-            { alt: "parceiros", src:  "https://media.graphassets.com/L3pDd52rQSMTxBA0iZCE", titulo: "Financeiro" },
-            { alt: "parceiros", src:  "https://media.graphassets.com/tPkMda4QqKTX3cXsW3SK", titulo: "Financeiro" },
-            { alt: "parceiros", src:  "https://media.graphassets.com/5uSM6yuT7ejQYRclwvAX", titulo: "Financeiro" },
-          ]}
-          theme="ColorAGP"
-          titulo="Apoio"
-        />
-        <Parcerias
-          parceiros={[
-            { alt: "parceiros", src:  res[0].logos[2].logo.url },
-            { alt: "parceiros", src: "https://media.graphassets.com/aWUhrz97TpWYaM8FZkOO" },
-            { alt: "parceiros", src: "https://media.graphassets.com/w0PeMRhSTMyiAJ6EoHCK" },
-            { alt: "parceiros", src: "https://media.graphassets.com/GFd1Fy4KSJ21lSJbJ7yo" },
-            { alt: "parceiros", src: "https://media.graphassets.com/zoaOCP3bTQurE4shNBPV" },
-            { alt: "parceiros", src: "https://media.graphassets.com/y7pE2JltSvSwpAhmyj1H" },
-            { alt: "parceiros", src: "https://media.graphassets.com/EQZ23JyZTN6RSJLCcJOK" },
-            { alt: "parceiros", src: "https://media.graphassets.com/NXzewu0rSDiofBLXyVbf" },
-            { alt: "parceiros", src: "https://media.graphassets.com/2js7q650SKW48aTqkzGT" },
-          ]}
-          theme="ColorAGP"
-          titulo="Governos Parceiros"
-        />
+        <div style = {{display:'flex',  justifyContent:'flex-start', flexDirection:'column'}} id ='parceiros-div' >
+          <Parcerias
+            parceiros={[
+              { alt: "parceiros", src: res[0].logos[4].logo.url, titulo: "Técnico e financeiro" },
+              { alt: "parceiros", src:  "https://media.graphassets.com/L3pDd52rQSMTxBA0iZCE", titulo: "Financeiro" },
+              { alt: "parceiros", src:  "https://media.graphassets.com/tPkMda4QqKTX3cXsW3SK", titulo: "Financeiro" },
+              { alt: "parceiros", src:  "https://media.graphassets.com/5uSM6yuT7ejQYRclwvAX", titulo: "Financeiro" },
+            ]}
+            theme="ColorAGP"
+            titulo="Apoio"
+          />
+          <Parcerias
+            parceiros={[
+              { alt: "parceiros", src:  res[0].logos[2].logo.url },
+              { alt: "parceiros", src: "https://media.graphassets.com/aWUhrz97TpWYaM8FZkOO" },
+              { alt: "parceiros", src: "https://media.graphassets.com/w0PeMRhSTMyiAJ6EoHCK" },
+              { alt: "parceiros", src: "https://media.graphassets.com/GFd1Fy4KSJ21lSJbJ7yo" },
+              { alt: "parceiros", src: "https://media.graphassets.com/zoaOCP3bTQurE4shNBPV" },
+              { alt: "parceiros", src: "https://media.graphassets.com/y7pE2JltSvSwpAhmyj1H" },
+              { alt: "parceiros", src: "https://media.graphassets.com/EQZ23JyZTN6RSJLCcJOK" },
+              { alt: "parceiros", src: "https://media.graphassets.com/NXzewu0rSDiofBLXyVbf" },
+              { alt: "parceiros", src: "https://media.graphassets.com/2js7q650SKW48aTqkzGT" },
+            ]}
+            theme="ColorAGP"
+            titulo="Governos Parceiros"
+          />
+        </div>
       </div>
 
     </>


### PR DESCRIPTION
<!--
TEMPLATE DE PULL REQUEST (PR)

- O QUE É?
  - Um modelo que traz os tópicos necessários para descrever um PR.

- QUAL O OBJETIVO?
  - Padronizar as descrições dos PRs nesse repositório e garantir que toda pessoa que os acesse tenha informações necessárias para entendê-los e usá-los.

- COMO USAR?
  - Siga os comentários de instrução presentes em cada seção abaixo para preenchê-las corretamente.

OBS: Não é necessário apagar os comentários, eles não aparecerão na descrição de seu PR.
-->

### Descrição
<!-- Descreva aqui o contexto de criação do PR, o que motivou a implementação dessas mudanças -->
Esse PR visa implementar o alinhamento dos títulos da seção de apoio e governos parceiros na página Home do painel. 
A proposta é implementar a mudança sugerida pela @tainnaps nesse [comentário](https://github.com/ImpulsoGov/SaudeMental/pull/108#pullrequestreview-1909293616), naquele momento não era uma prioridade, no entanto agora foi possível.

### Objetivos
<!-- Descreva aqui as mudanças que esse PR se destina a fazer -->
Alinhar os títulos das seções de Apoio e Governos Parceiros

### Checklist de Validação
<!--
Descreva aqui o que a pessoa revisora desse PR deve fazer para validar as alterações feitas, ex:
- Interaja com os filtros do gráfico selecionando múltiplas competências e/ou estabelecimentos (tente selecionar estabelecimentos com nomes compostos) para observar se erros inesperados acontecem.
- Remova todos os valores dos filtros e observe se é exibida a mensagem "Sem dados nessa competência".
- Compare os valores exibidos pelo gráfico na versão local com os valores exibidos pelo gráfico na versão de produção do site.

Tente pensar no caminho natural ao usar a funcionalidade e também nos casos extremos.
-->

<!-- Marque os checkboxes abaixo à medida em que as tarefas são feitas e garanta que todas elas sejam realizadas antes de mergear o PR -->
Verifique o alinhamento dos títulos das seções de Apoio e Governos Parceiros para as seguintes resoluções:
- [ ] 1366x768
- [ ] 1280x1024
